### PR TITLE
Create simple_fuzzer.c

### DIFF
--- a/fuzzer/simple_fuzzer.c
+++ b/fuzzer/simple_fuzzer.c
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "nostrdb.h"
+
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+__AFL_FUZZ_INIT();
+
+int main(void) {
+    while (__AFL_LOOP(1000000)) {
+        unsigned char *buf = __AFL_FUZZ_TESTCASE_BUF;
+        size_t len = __AFL_FUZZ_TESTCASE_LEN;
+        struct ndb *db;
+        int init_result = ndb_init(&db, 1024, 1);
+        if (init_result != 1) {
+            fprintf(stderr, "Failed to initialize nostrdb\n");
+            continue;
+        }
+        int result = ndb_process_event(db, (const char *)buf, len);
+        if (result == 0) {
+            if (len >= 32) {
+                struct ndb_note *note = ndb_get_note_by_id(db, buf);
+                if (note != NULL) {
+                }
+            }
+        } else {
+        }
+        ndb_destroy(db);
+    }
+    return 0;
+}


### PR DESCRIPTION
simple and inefficient AFL fuzzer for nostrdb
responsible for finding
 1x global buffer overflow
 1x Floating Point Exception (div by zero)
 1x Assertion failure
 
How to use it yourself:
1. Install Clang 14+
2. Install LLVM 14+
3. Install AFL++
4. Then...
 AFL_USE_ASAN=1 afl-clang-lto -flto=full -fsanitize=address -Wall -Wno-unused-function -Werror -O2 -g -Ideps/secp256k1/include -Ideps/lmdb -Ideps/flatcc/include fuzzer.c nostrdb.c sha256.c deps/flatcc/src/runtime/json_parser.c deps/flatcc/src/runtime/builder.c deps/flatcc/src/runtime/emitter.c deps/flatcc/src/runtime/refmap.c deps/lmdb/liblmdb.a deps/secp256k1/.libs/libsecp256k1.a -o fuzzer
5. create an input directory drop some sort of starting corpus. i chose blns.txt because it rocks. 
6. afl-fuzz -i $input -o $output -- ./fuzzer 
 
![image](https://github.com/damus-io/nostrdb/assets/466878/d29e5db8-4bfc-4e4b-8e71-67ddfc4b6537)

