### PR TITLE
Delete unuse argument (destsize)

### DIFF
--- a/hex.h
+++ b/hex.h
@@ -50,7 +50,7 @@ static inline char hexchar(unsigned int val)
 	abort();
 }
 
-static int hex_encode(const void *buf, size_t bufsize, char *dest, size_t destsize)
+static int hex_encode(const void *buf, size_t bufsize, char *dest)
 {
 	size_t i;
 

--- a/nostrdb.c
+++ b/nostrdb.c
@@ -3616,7 +3616,7 @@ static int ndb_event_commitment(struct ndb_note *ev, unsigned char *buf, int buf
 	struct cursor cur;
 	int ok;
 
-	if (!hex_encode(ev->pubkey, sizeof(ev->pubkey), pubkey, sizeof(pubkey)))
+	if (!hex_encode(ev->pubkey, sizeof(ev->pubkey), pubkey))
 		return 0;
 
 	make_cursor(buf, buf + buflen, &cur);


### PR DESCRIPTION
Hi !
I'm hakkadaikon. (npub: npub1zqdnpm5gcfap8hngha7gcp3k363786phvs2etsvxw4nh6x9ydfzsuyk6mn)

I added this because there was no destsize check in the hex_encode method.
Please check. 🙏