### PR TITLE
Specify build environment in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ settings
 	-d <db_dir>          set database directory
 ```
 
-### Building
+### Building (Linux only)
 
 ```bash
 $ make ndb


### PR DESCRIPTION
Just tried on OSX, it fails, because of some dependencies are missing, so it's good to specify the environment