### PR TITLE
Add required dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ settings
 
 ### Building
 
+#### Dependencies required
+
+- curl
+- autoconf
+- libtool
+
+
 ```bash
 $ make ndb
 ```

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ settings
 
 #### Dependencies required
 
-- curl
 - autoconf
 - libtool
 


### PR DESCRIPTION
fixes #22 

~3 _required_ dependencies are missing to be able to install the project properly.~

As for Mac OS (In my case Sonoma), I have to write `byteswap.h` to `/usr/local/include/`

```c
#if defined(__APPLE__)
// Mac OS X / Darwin features
#include <libkern/OSByteOrder.h>
#define bswap_16(x) OSSwapInt16(x)
#define bswap_32(x) OSSwapInt32(x)
#define bswap_64(x) OSSwapInt64(x)
#endif
```

edit: 2 _required_ dependencies are needed to be able to install the project properly.