### PR TITLE
Fix issue where id tag filters are pushed as strings

### DIFF
--- a/src/nostrdb.c
+++ b/src/nostrdb.c
@@ -784,8 +784,18 @@ static int ndb_filter_add_element(struct ndb_filter *filter, union ndb_filter_el
 		offset = el.integer;
 		break;
 	case NDB_FILTER_TAGS:
-		if (!cursor_push_c_str(&filter->data_buf, el.string))
+		switch (current->field.elem_type) {
+		case NDB_ELEMENT_ID:
+			if (!cursor_push(&filter->data_buf, (unsigned char *)el.id, 32))
+				return 0;
+			break;
+		case NDB_ELEMENT_STRING:
+			if (!cursor_push_c_str(&filter->data_buf, el.string))
+				return 0;
+			break;
+		case NDB_ELEMENT_UNKNOWN:
 			return 0;
+		}
 		// push a pointer of the string in the databuf as an element
 		break;
 	}

--- a/test.c
+++ b/test.c
@@ -1546,8 +1546,8 @@ int main(int argc, const char *argv[]) {
 	test_bech32_parsing();
 	test_single_url_parsing();
 	test_url_parsing();
-	test_weird_note_corruption();
 	test_query();
+	test_weird_note_corruption();
 	test_tag_query();
 	test_parse_content();
 	test_subscriptions();


### PR DESCRIPTION
When creating filters, sometimes IDs are pushed as strings, so if there is ever a 0 byte, the id prematurely ends, causing the filter to not match

Fixes: https://github.com/rust-nostr/nostr/issues/454