### PR TITLE
Minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,9 @@ CHECKDATA=testdata/db/v0/data.mdb
 
 all: $(BIN) lib bench
 
-%.o: %.c $(HEADERS)
+$(OBJS): $(HEADERS)
+
+%.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 libnostrdb.a: $(OBJS)

--- a/src/content_parser.c
+++ b/src/content_parser.c
@@ -91,8 +91,8 @@ static int parse_hashtag(struct cursor *cur, struct ndb_block *block) {
 //
 // bech32 blocks are stored as:
 //
-//     nostr_bech32_type  : varint
 //     bech32_buffer_size : u16
+//     nostr_bech32_type  : varint
 //     bech32_data        : [u8]
 //
 // The TLV form is compact already, so we just use it directly

--- a/src/nostrdb.c
+++ b/src/nostrdb.c
@@ -5065,7 +5065,7 @@ static inline int ndb_builder_find_str(struct ndb_builder *builder,
 		uint32_t index = ((uint32_t*)builder->str_indices.start)[i];
 		const char *some_str = (const char*)builder->strings.start + index;
 
-		if (!memcmp(some_str, str, len)) {
+		if (!memcmp(some_str, str, len) && some_str[len] == '\0') {
 			// found an existing matching str, use that index
 			*pstr = ndb_offset_str(index);
 			return 1;


### PR DESCRIPTION
I've got a massive rework of your cursor routines, but it turned up four problems.

Three are fixed here, the other I'm not so sure of.  This line in content_parser.c is completely bogus:

```
	parser.blocks->blocks_size = parser.buffer.p - blocks_start;
```

These are not even pointers into the same buffer, so block_size is set to random bignum.  Fortunately the code which uses it as a limit doesn't hit the limit...

