### PR TITLE
Add a new `rcur` read-only cursor type, adapt code to use it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ CFLAGS = -Wall -Wno-misleading-indentation -Wno-unused-function -Werror -O2 -g -
 BOLT11_HDRS := src/bolt11/amount.h src/bolt11/bech32.h src/bolt11/bech32_util.h src/bolt11/bolt11.h src/bolt11/debug.h src/bolt11/error.h src/bolt11/hash_u5.h src/bolt11/node_id.h src/bolt11/overflows.h
 CCAN_SRCS := ccan/ccan/utf8/utf8.c ccan/ccan/tal/tal.c ccan/ccan/tal/str/str.c ccan/ccan/list/list.c ccan/ccan/mem/mem.c ccan/ccan/crypto/sha256/sha256.c ccan/ccan/take/take.c
 CCAN_HDRS := ccan/ccan/utf8/utf8.h ccan/ccan/container_of/container_of.h ccan/ccan/check_type/check_type.h ccan/ccan/str/str.h ccan/ccan/tal/str/str.h ccan/ccan/tal/tal.h ccan/ccan/list/list.h ccan/ccan/structeq/structeq.h ccan/ccan/typesafe_cb/typesafe_cb.h ccan/ccan/short_types/short_types.h ccan/ccan/mem/mem.h ccan/ccan/likely/likely.h ccan/ccan/alignof/alignof.h ccan/ccan/crypto/sha256/sha256.h ccan/ccan/array_size/array_size.h ccan/ccan/endian/endian.h ccan/ccan/take/take.h ccan/ccan/build_assert/build_assert.h ccan/ccan/cppmagic/cppmagic.h
-HEADERS = deps/lmdb/lmdb.h deps/secp256k1/include/secp256k1.h src/nostrdb.h src/cursor.h src/hex.h src/jsmn.h src/config.h src/random.h src/memchr.h src/cpu.h src/nostr_bech32.h src/block.h src/str_block.h $(C_BINDINGS) $(CCAN_HDRS) $(BOLT11_HDRS)
+HEADERS = deps/lmdb/lmdb.h deps/secp256k1/include/secp256k1.h src/nostrdb.h src/cursor.h src/hex.h src/jsmn.h src/config.h src/random.h src/memchr.h src/cpu.h src/nostr_bech32.h src/block.h src/str_block.h src/rcur.h $(C_BINDINGS) $(CCAN_HDRS) $(BOLT11_HDRS)
 FLATCC_SRCS=deps/flatcc/src/runtime/json_parser.c deps/flatcc/src/runtime/verifier.c deps/flatcc/src/runtime/builder.c deps/flatcc/src/runtime/emitter.c deps/flatcc/src/runtime/refmap.c
 BOLT11_SRCS = src/bolt11/bolt11.c src/bolt11/bech32.c src/bolt11/amount.c src/bolt11/hash_u5.c
-SRCS = src/nostrdb.c src/invoice.c src/nostr_bech32.c src/content_parser.c src/block.c $(BOLT11_SRCS) $(FLATCC_SRCS) $(CCAN_SRCS)
+SRCS = src/nostrdb.c src/invoice.c src/nostr_bech32.c src/content_parser.c src/block.c src/rcur.c $(BOLT11_SRCS) $(FLATCC_SRCS) $(CCAN_SRCS)
 LDS = $(OBJS) $(ARS) 
 OBJS = $(SRCS:.c=.o)
 DEPS = $(OBJS) $(HEADERS) $(ARS)

--- a/src/block.c
+++ b/src/block.c
@@ -106,24 +106,14 @@ enum ndb_block_type ndb_get_block_type(struct ndb_block *block) {
 void ndb_blocks_iterate_start(const char *content, struct ndb_blocks *blocks, struct ndb_block_iterator *iter) {
 	iter->blocks = blocks;
 	iter->content = content;
-	iter->p = blocks->blocks;
+	iter->rcur = rcur_forbuf(blocks->blocks, iter->blocks->blocks_size);
 }
 
 struct ndb_block *ndb_blocks_iterate_next(struct ndb_block_iterator *iter)
 {
-	struct rcur rcur;
-
-	/* FIXME: why not make iter an rcur? */
-	rcur = rcur_forbuf(iter->blocks->blocks, iter->blocks->blocks_size);
-	rcur.p = iter->p;
-
-	if (!rcur_bytes_remaining(rcur))
+	if (!pull_block(iter->content, &iter->rcur, &iter->block))
 		return NULL;
 
-	if (!pull_block(iter->content, &rcur, &iter->block))
-		return NULL;
-
-	iter->p = rcur.p;
 	return &iter->block;
 }
 

--- a/src/block.c
+++ b/src/block.c
@@ -60,13 +60,20 @@ static int pull_bech32_mention(const char *content, struct cursor *cur, struct n
 	return 1;
 }
 
-static int pull_invoice(const char *content, struct cursor *cur,
-			struct ndb_invoice_block *block)
+static bool pull_invoice(const char *content, struct cursor *cur,
+			 struct ndb_invoice_block *block)
 {
-	if (!pull_str_block(cur, content, &block->invstr))
-		return 0;
+	bool ret;
+	struct rcur rcur;
 
-	return ndb_decode_invoice(cur, &block->invoice);
+	if (!pull_str_block(cur, content, &block->invstr))
+		return false;
+
+	rcur = rcur_from_cursor(cur);
+	ret = ndb_decode_invoice(&rcur, &block->invoice);
+	*cur = cursor_from_rcur(&rcur);
+
+	return ret;
 }
 
 static int pull_block_type(struct cursor *cur, enum ndb_block_type *type)

--- a/src/block.c
+++ b/src/block.c
@@ -2,6 +2,7 @@
 
 #include "nostrdb.h"
 #include "block.h"
+#include "rcur.h"
 #include <stdlib.h>
 
 int push_str_block(struct cursor *buf, const char *content, struct ndb_str_block *block) {
@@ -36,7 +37,7 @@ static int pull_nostr_bech32_type(struct cursor *cur, enum nostr_bech32_type *ty
 static int pull_bech32_mention(const char *content, struct cursor *cur, struct ndb_mention_bech32_block *block) {
 	uint16_t size;
 	unsigned char *start;
-	struct cursor bech32;
+	struct rcur bech32;
 
 	if (!pull_str_block(cur, content, &block->str))
 		return 0;
@@ -47,7 +48,7 @@ static int pull_bech32_mention(const char *content, struct cursor *cur, struct n
 	if (!pull_nostr_bech32_type(cur, &block->bech32.type))
 		return 0;
 
-	make_cursor(cur->p, cur->p + size, &bech32);
+	bech32 = rcur_forbuf(cur->p, size);
 
 	start = cur->p;
 

--- a/src/block.h
+++ b/src/block.h
@@ -8,6 +8,7 @@
 #include "nostr_bech32.h"
 #include "nostrdb.h"
 #include <inttypes.h>
+#include <stdbool.h>
 
 #define NDB_BLOCK_FLAG_OWNED 1
 
@@ -29,8 +30,9 @@ struct ndb_blocks {
 
 #pragma pack(pop)
 
-int push_str_block(struct cursor *buf, const char *content, struct ndb_str_block *block);
-int pull_str_block(struct cursor *buf, const char *content, struct ndb_str_block *block);
+struct rcur;
 
+int push_str_block(struct cursor *buf, const char *content, struct ndb_str_block *block);
+bool pull_str_block(struct rcur *rcur, const char *content, struct ndb_str_block *block);
 
 #endif // NDB_BLOCK_H

--- a/src/content_parser.c
+++ b/src/content_parser.c
@@ -323,28 +323,26 @@ static int consume_url_fragment(struct cursor *cur)
 	return consume_until_end_url(cur, 1);
 }
 
-static int consume_url_path(struct cursor *cur)
+static void consume_url_path(struct cursor *cur)
 {
 	int c;
 
 	if ((c = peek_char(cur, 0)) < 0)
-		return 1;
+		return;
 
 	if (c != '/') {
-		return 1;
+		return;
 	}
 
 	while (cur->p < cur->end) {
 		c = *cur->p;
 
 		if (c == '?' || c == '#' || is_final_url_char(cur->p, cur->end)) {
-			return 1;
+			return;
 		}
 
 		cur->p++;
 	}
-
-	return 1;
 }
 
 static int consume_url_host(struct cursor *cur)
@@ -412,10 +410,7 @@ static int parse_url(struct cursor *cur, struct ndb_block *block) {
 	// skip leading /
 	cursor_skip(&path_cur, 1);
 
-	if (!consume_url_path(cur)) {
-		cur->p = start;
-		return 0;
-	}
+	consume_url_path(cur);
 
 	if (!consume_url_fragment(cur)) {
 		cur->p = start;

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -94,7 +94,7 @@ static inline void copy_cursor(struct cursor *src, struct cursor *dest)
 
 static inline int cursor_skip(struct cursor *cursor, int n)
 {
-    if (cursor->p + n >= cursor->end)
+    if (cursor->p + n > cursor->end)
         return 0;
 
     cursor->p += n;

--- a/src/invoice.h
+++ b/src/invoice.h
@@ -7,9 +7,10 @@
 #include "nostrdb.h"
 
 struct bolt11;
+struct rcur;
 
 // ENCODING
 int ndb_encode_invoice(struct cursor *cur, struct bolt11 *invoice);
-int ndb_decode_invoice(struct cursor *cur, struct ndb_invoice *invoice);
+bool ndb_decode_invoice(struct rcur *rcur, struct ndb_invoice *invoice);
 
 #endif /* NDB_INVOICE_H */

--- a/src/nostr_bech32.c
+++ b/src/nostr_bech32.c
@@ -251,21 +251,22 @@ bool parse_nostr_bech32_str(struct rcur *bech32, enum nostr_bech32_type *type) {
 bool parse_nostr_bech32(unsigned char *buf, int buflen,
 			const char *bech32_str, size_t bech32_len,
 			struct nostr_bech32 *obj) {
-	const unsigned char *start;
+	const unsigned char *start = (const unsigned char *)bech32_str;
 	size_t parsed_len, u5_out_len, u8_out_len;
 	enum nostr_bech32_type type;
 	static const int MAX_PREFIX = 8;
 	struct cursor cur;
-	struct rcur bech32, u8;
+	struct rcur test, bech32, u8;
 
 	make_cursor(buf, buf + buflen, &cur);
-	bech32 = rcur_forbuf(bech32_str, bech32_len);
-	
-	start = bech32.p;
-	if (!parse_nostr_bech32_str(&bech32, &type))
+
+	// parse_nostr_bech32_str consumes the copy
+	test = bech32 = rcur_forbuf(start, bech32_len);
+
+	if (!parse_nostr_bech32_str(&test, &type))
 		return 0;
 
-	parsed_len = bech32.p - start;
+	parsed_len = rcur_bytes_remaining(rcur_between(&bech32, &test));
 
 	// some random sanity checking
 	if (parsed_len < 10 || parsed_len > 10000)

--- a/src/nostr_bech32.c
+++ b/src/nostr_bech32.c
@@ -7,10 +7,11 @@
 
 #include "nostr_bech32.h"
 #include <stdlib.h>
-#include "cursor.h"
 #include "str_block.h"
 #include "nostrdb.h"
 #include "bolt11/bech32.h"
+#include "ccan/array_size/array_size.h"
+#include "rcur.h"
 
 #define MAX_TLVS 32
 
@@ -26,83 +27,71 @@ struct nostr_tlv {
 	const unsigned char *value;
 };
 
-static int parse_nostr_tlv(struct cursor *cur, struct nostr_tlv *tlv) {
-	// get the tlv tag
-	if (!cursor_pull_byte(cur, &tlv->type))
-		return 0;
+/* Returns false on error, *or* empty */
+static bool parse_nostr_tlv(struct rcur *rcur, struct nostr_tlv *tlv)
+{
+	if (!rcur_bytes_remaining(*rcur))
+		return false;
+	tlv->type = rcur_pull_byte(rcur);
+	tlv->len = rcur_pull_byte(rcur);
+	tlv->value = rcur_pull(rcur, tlv->len);
 
-	if (tlv->type >= TLV_KNOWN_TLVS)
-		return 0;
-	
-	// get the length
-	if (!cursor_pull_byte(cur, &tlv->len))
-		return 0;
-	
-	// is the reported length greater then our buffer? if so fail
-	if (cur->p + tlv->len > cur->end)
-		return 0;
-	
-	tlv->value = cur->p;
-	cur->p += tlv->len;
-	
-	return 1;
+	return tlv->value != NULL;
 }
 
-int parse_nostr_bech32_type(const char *prefix, enum nostr_bech32_type *type) {
-	// Parse type
-	if (strncmp(prefix, "note", 4) == 0) {
-		*type = NOSTR_BECH32_NOTE;
-		return 4;
-	} else if (strncmp(prefix, "npub", 4) == 0) {
-		*type = NOSTR_BECH32_NPUB;
-		return 4;
-	} else if (strncmp(prefix, "nsec", 4) == 0) {
-		*type = NOSTR_BECH32_NSEC;
-		return 4;
-	} else if (strncmp(prefix, "nprofile", 8) == 0) {
-		*type = NOSTR_BECH32_NPROFILE;
-		return 8;
-	} else if (strncmp(prefix, "nevent", 6) == 0) {
-		*type = NOSTR_BECH32_NEVENT;
-		return 6;
-	} else if (strncmp(prefix, "nrelay", 6) == 0) {
-		*type = NOSTR_BECH32_NRELAY;
-		return 6;
-	} else if (strncmp(prefix, "naddr", 5) == 0) {
-		*type = NOSTR_BECH32_NADDR;
-		return 5;
+enum nostr_bech32_type parse_nostr_bech32_type(struct rcur *typestr)
+{
+	struct {
+		const char *name;
+		enum nostr_bech32_type type;
+	} table[] = {
+		{"note", NOSTR_BECH32_NOTE},
+		{"npub", NOSTR_BECH32_NPUB},
+		{"nsec", NOSTR_BECH32_NSEC},
+		{"nprofile", NOSTR_BECH32_NPROFILE},
+		{"nevent", NOSTR_BECH32_NEVENT},
+		{"nrelay", NOSTR_BECH32_NRELAY},
+		{"naddr", NOSTR_BECH32_NADDR},
+	};
+
+	for (size_t i = 0; i < ARRAY_SIZE(table); i++) {
+		if (rcur_skip_if_match(typestr,
+				       table[i].name, strlen(table[i].name)))
+			return table[i].type;
 	}
-	
+
+	rcur_fail(typestr);
 	return 0;
 }
 
-static int parse_nostr_bech32_note(struct cursor *cur, struct bech32_note *note) {
-	return pull_bytes(cur, 32, &note->event_id);
+static void parse_nostr_bech32_note(struct rcur *rcur, struct bech32_note *note) {
+	note->event_id = rcur_pull(rcur, 32);
 }
 
-static int parse_nostr_bech32_npub(struct cursor *cur, struct bech32_npub *npub) {
-	return pull_bytes(cur, 32, &npub->pubkey);
+static void parse_nostr_bech32_npub(struct rcur *rcur, struct bech32_npub *npub) {
+	npub->pubkey = rcur_pull(rcur, 32);
 }
 
-static int parse_nostr_bech32_nsec(struct cursor *cur, struct bech32_nsec *nsec) {
-	return pull_bytes(cur, 32, &nsec->nsec);
+static void parse_nostr_bech32_nsec(struct rcur *rcur, struct bech32_nsec *nsec) {
+	nsec->nsec = rcur_pull(rcur, 32);
 }
 
-static int add_relay(struct ndb_relays *relays, struct nostr_tlv *tlv)
+/* FIXME: Nobody checks this return? */
+static bool add_relay(struct ndb_relays *relays, struct nostr_tlv *tlv)
 {
 	struct ndb_str_block *str;
 
 	if (relays->num_relays + 1 > NDB_MAX_RELAYS)
-		return 0;
+		return false;
 	
 	str = &relays->relays[relays->num_relays++];
 	str->str = (const char*)tlv->value;
 	str->len = tlv->len;
 	
-	return 1;
+	return true;
 }
 
-static int parse_nostr_bech32_nevent(struct cursor *cur, struct bech32_nevent *nevent) {
+static bool parse_nostr_bech32_nevent(struct rcur *rcur, struct bech32_nevent *nevent) {
 	struct nostr_tlv tlv;
 	int i;
 
@@ -111,18 +100,18 @@ static int parse_nostr_bech32_nevent(struct cursor *cur, struct bech32_nevent *n
 	nevent->relays.num_relays = 0;
 
 	for (i = 0; i < MAX_TLVS; i++) {
-		if (!parse_nostr_tlv(cur, &tlv))
+		if (!parse_nostr_tlv(rcur, &tlv))
 			break;
 
 		switch (tlv.type) {
 		case TLV_SPECIAL:
 			if (tlv.len != 32)
-				return 0;
+				return rcur_fail(rcur);
 			nevent->event_id = tlv.value;
 			break;
 		case TLV_AUTHOR:
 			if (tlv.len != 32)
-				return 0;
+				return rcur_fail(rcur);
 			nevent->pubkey = tlv.value;
 			break;
 		case TLV_RELAY:
@@ -131,10 +120,12 @@ static int parse_nostr_bech32_nevent(struct cursor *cur, struct bech32_nevent *n
 		}
 	}
 
-	return nevent->event_id != NULL;
+	if (nevent->event_id == NULL)
+		return rcur_fail(rcur);
+	return true;
 }
 
-static int parse_nostr_bech32_naddr(struct cursor *cur, struct bech32_naddr *naddr) {
+static bool parse_nostr_bech32_naddr(struct rcur *rcur, struct bech32_naddr *naddr) {
 	struct nostr_tlv tlv;
 	int i;
 
@@ -144,7 +135,7 @@ static int parse_nostr_bech32_naddr(struct cursor *cur, struct bech32_naddr *nad
 	naddr->relays.num_relays = 0;
 
 	for (i = 0; i < MAX_TLVS; i++) {
-		if (!parse_nostr_tlv(cur, &tlv))
+		if (!parse_nostr_tlv(rcur, &tlv))
 			break;
 
 		switch (tlv.type) {
@@ -153,7 +144,7 @@ static int parse_nostr_bech32_naddr(struct cursor *cur, struct bech32_naddr *nad
 			naddr->identifier.len = tlv.len;
 			break;
 		case TLV_AUTHOR:
-			if (tlv.len != 32) return 0;
+			if (tlv.len != 32) return false;
 			naddr->pubkey = tlv.value;
 			break;
 		case TLV_RELAY:
@@ -162,10 +153,12 @@ static int parse_nostr_bech32_naddr(struct cursor *cur, struct bech32_naddr *nad
 		}
 	}
 
-	return naddr->identifier.str != NULL;
+	if (naddr->identifier.str == NULL)
+		return rcur_fail(rcur);
+	return true;
 }
 
-static int parse_nostr_bech32_nprofile(struct cursor *cur, struct bech32_nprofile *nprofile) {
+static bool parse_nostr_bech32_nprofile(struct rcur *rcur, struct bech32_nprofile *nprofile) {
 	struct nostr_tlv tlv;
 	int i;
 
@@ -173,12 +166,12 @@ static int parse_nostr_bech32_nprofile(struct cursor *cur, struct bech32_nprofil
 	nprofile->relays.num_relays = 0;
 
 	for (i = 0; i < MAX_TLVS; i++) {
-		if (!parse_nostr_tlv(cur, &tlv))
+		if (!parse_nostr_tlv(rcur, &tlv))
 			break;
 
 		switch (tlv.type) {
 		case TLV_SPECIAL:
-			if (tlv.len != 32) return 0;
+			if (tlv.len != 32) return rcur_fail(rcur);
 			nprofile->pubkey = tlv.value;
 			break;
 		case TLV_RELAY:
@@ -187,10 +180,12 @@ static int parse_nostr_bech32_nprofile(struct cursor *cur, struct bech32_nprofil
 		}
 	}
 
-	return nprofile->pubkey != NULL;
+	if (nprofile->pubkey == NULL)
+		return rcur_fail(rcur);
+	return true;
 }
 
-static int parse_nostr_bech32_nrelay(struct cursor *cur, struct bech32_nrelay *nrelay) {
+static bool parse_nostr_bech32_nrelay(struct rcur *rcur, struct bech32_nrelay *nrelay) {
 	struct nostr_tlv tlv;
 	int i;
 
@@ -198,7 +193,7 @@ static int parse_nostr_bech32_nrelay(struct cursor *cur, struct bech32_nrelay *n
 	nrelay->relay.len = 0;
 
 	for (i = 0; i < MAX_TLVS; i++) {
-		if (!parse_nostr_tlv(cur, &tlv))
+		if (!parse_nostr_tlv(rcur, &tlv))
 			break;
 
 		switch (tlv.type) {
@@ -209,88 +204,62 @@ static int parse_nostr_bech32_nrelay(struct cursor *cur, struct bech32_nrelay *n
 		}
 	}
 	
-	return nrelay->relay.str != NULL;
+	if (nrelay->relay.str == NULL)
+		return rcur_fail(rcur);
+	return true;
 }
 
-int parse_nostr_bech32_buffer(struct cursor *cur,
-			      enum nostr_bech32_type type,
-			      struct nostr_bech32 *obj)
+bool parse_nostr_bech32_buffer(struct rcur *rcur,
+			       enum nostr_bech32_type type,
+			       struct nostr_bech32 *obj)
 {
 	obj->type = type;
 	
 	switch (obj->type) {
 		case NOSTR_BECH32_NOTE:
-			if (!parse_nostr_bech32_note(cur, &obj->note))
-				return 0;
+			parse_nostr_bech32_note(rcur, &obj->note);
 			break;
 		case NOSTR_BECH32_NPUB:
-			if (!parse_nostr_bech32_npub(cur, &obj->npub))
-				return 0;
+			parse_nostr_bech32_npub(rcur, &obj->npub);
 			break;
 		case NOSTR_BECH32_NSEC:
-			if (!parse_nostr_bech32_nsec(cur, &obj->nsec))
-				return 0;
+			parse_nostr_bech32_nsec(rcur, &obj->nsec);
 			break;
 		case NOSTR_BECH32_NEVENT:
-			if (!parse_nostr_bech32_nevent(cur, &obj->nevent))
-				return 0;
+			parse_nostr_bech32_nevent(rcur, &obj->nevent);
 			break;
 		case NOSTR_BECH32_NADDR:
-			if (!parse_nostr_bech32_naddr(cur, &obj->naddr))
-				return 0;
+			parse_nostr_bech32_naddr(rcur, &obj->naddr);
 			break;
 		case NOSTR_BECH32_NPROFILE:
-			if (!parse_nostr_bech32_nprofile(cur, &obj->nprofile))
-				return 0;
+			parse_nostr_bech32_nprofile(rcur, &obj->nprofile);
 			break;
 		case NOSTR_BECH32_NRELAY:
-			if (!parse_nostr_bech32_nrelay(cur, &obj->nrelay))
-				return 0;
+			parse_nostr_bech32_nrelay(rcur, &obj->nrelay);
 			break;
 	}
-
-	return 1;
+	return rcur_valid(rcur);
 }
 
-
-int parse_nostr_bech32_str(struct cursor *bech32, enum nostr_bech32_type *type) {
-	unsigned char *start = bech32->p;
-	unsigned char *data_start;
-	int n;
-
-	if (!(n = parse_nostr_bech32_type((const char *)bech32->p, type))) {
-		bech32->p = start;
-		return 0;
-	}
-	
-	data_start = start + n;
-	if (!consume_until_non_alphanumeric(bech32, 1)) {
-		bech32->p = start;
-		return 0;
-	}
-
+bool parse_nostr_bech32_str(struct rcur *bech32, enum nostr_bech32_type *type) {
+	*type = parse_nostr_bech32_type(bech32);
 	// must be at least 59 chars for the data part
-	//ndb_debug("bech32_data_size %ld '%c' '%c' '%.*s'\n", bech32->p - data_start, *(bech32->p-1), *data_start, (int)(bech32->p - data_start), data_start);
-	if (bech32->p - data_start < 59) {
-		bech32->p = start;
-		return 0;
-	}
-
-	return 1;
+	return rcur_pull_non_alphanumeric(bech32) >= 59;
 }
 
 
-int parse_nostr_bech32(unsigned char *buf, int buflen,
-		       const char *bech32_str, size_t bech32_len,
-		       struct nostr_bech32 *obj) {
-	unsigned char *start;
+bool parse_nostr_bech32(unsigned char *buf, int buflen,
+			const char *bech32_str, size_t bech32_len,
+			struct nostr_bech32 *obj) {
+	const unsigned char *start;
 	size_t parsed_len, u5_out_len, u8_out_len;
 	enum nostr_bech32_type type;
 	static const int MAX_PREFIX = 8;
-	struct cursor cur, bech32, u8;
+	struct cursor cur;
+	struct rcur bech32, u8;
 
 	make_cursor(buf, buf + buflen, &cur);
-	make_cursor((unsigned char*)bech32_str, (unsigned char*)bech32_str + bech32_len, &bech32);
+	bech32 = rcur_forbuf(bech32_str, bech32_len);
 	
 	start = bech32.p;
 	if (!parse_nostr_bech32_str(&bech32, &type))
@@ -314,7 +283,7 @@ int parse_nostr_bech32(unsigned char *buf, int buflen,
 	if (!bech32_convert_bits(cur.p, &u8_out_len, 8, u5, u5_out_len, 5, 0))
 		return 0;
 
-	make_cursor(cur.p, cur.p + u8_out_len, &u8);
+	u8 = rcur_forbuf(cur.p, u8_out_len);
 
 	return parse_nostr_bech32_buffer(&u8, type, obj);
 }

--- a/src/nostr_bech32.h
+++ b/src/nostr_bech32.h
@@ -11,17 +11,20 @@
 #include <stdio.h>
 #include "str_block.h"
 #include "nostrdb.h"
-#include "cursor.h"
 
-int parse_nostr_bech32_str(struct cursor *bech32, enum nostr_bech32_type *type);
-int parse_nostr_bech32_type(const char *prefix, enum nostr_bech32_type *type);
+struct rcur;
 
-int parse_nostr_bech32_buffer(struct cursor *cur, enum nostr_bech32_type type,
-			      struct nostr_bech32 *obj);
+bool parse_nostr_bech32_str(struct rcur *bech32, enum nostr_bech32_type *type);
 
-int parse_nostr_bech32(unsigned char *buf, int buflen,
-		       const char *bech32_str, size_t bech32_len,
-		       struct nostr_bech32 *obj);
+/* Check rcur_valid(typestr) to determine if it failed */
+enum nostr_bech32_type parse_nostr_bech32_type(struct rcur *typestr);
+
+bool parse_nostr_bech32_buffer(struct rcur *rcur, enum nostr_bech32_type type,
+			       struct nostr_bech32 *obj);
+
+bool parse_nostr_bech32(unsigned char *buf, int buflen,
+			const char *bech32_str, size_t bech32_len,
+			struct nostr_bech32 *obj);
 
 /*
 int parse_nostr_bech32(const char *bech32, size_t input_len,

--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -3,6 +3,7 @@
 
 #include <inttypes.h>
 #include "cursor.h"
+#include "rcur.h"
 
 // maximum number of filters allowed in a filter group
 #define NDB_PACKED_STR     0x1
@@ -419,7 +420,7 @@ struct ndb_block_iterator {
 	const char *content;
 	struct ndb_blocks *blocks;
 	struct ndb_block block;
-	const unsigned char *p;
+	struct rcur rcur;
 };
 
 struct ndb_query_result {

--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -419,7 +419,7 @@ struct ndb_block_iterator {
 	const char *content;
 	struct ndb_blocks *blocks;
 	struct ndb_block block;
-	unsigned char *p;
+	const unsigned char *p;
 };
 
 struct ndb_query_result {

--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -294,7 +294,7 @@ struct ndb_stat {
 // see `ndb_make_text_search_key` for how the packed version is constructed
 struct ndb_text_search_key
 {
-	int str_len;
+	size_t str_len;
 	const char *str;
 	uint64_t timestamp;
 	uint64_t note_id;

--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -396,8 +396,8 @@ struct ndb_invoice {
 	uint64_t amount;
 	uint64_t timestamp;
 	uint64_t expiry;
-	char *description;
-	unsigned char *description_hash;
+	const char *description;
+	const unsigned char *description_hash;
 };
 
 struct ndb_invoice_block {

--- a/src/print_util.h
+++ b/src/print_util.h
@@ -3,7 +3,7 @@
 
 static void ndb_print_text_search_key(struct ndb_text_search_key *key)
 {
-	fprintf(stderr,"K<'%.*s' %" PRIu64 " %" PRIu64 " note_id:%" PRIu64 ">", key->str_len, key->str,
+	fprintf(stderr,"K<'%.*s' %" PRIu64 " %" PRIu64 " note_id:%" PRIu64 ">", (int)key->str_len, key->str,
 						    key->word_index,
 						    key->timestamp,
 						    key->note_id);

--- a/src/rcur.c
+++ b/src/rcur.c
@@ -17,19 +17,16 @@ const void *rcur_pull(struct rcur *rcur, size_t len)
 	rcur_fail(rcur);
 	return NULL;
     }
-    rcur->p += len;
-    return rcur->p - len;
+    rcur->cur += len;
+    rcur->len -= len;
+    return p;
 }
 
 /* Access the remaining bytes.  Returns NULL and *len=0 if invalid. */
 const void *rcur_peek_remainder(const struct rcur *rcur, size_t *len)
 {
-    if (!rcur_valid(rcur)) {
-	*len = 0;
-	return NULL;
-    }
-    *len = rcur->end - rcur->p;
-    return rcur->p;
+    *len = rcur->len;
+    return rcur->cur;
 }
 
 bool rcur_copy(struct rcur *rcur, void *dst, size_t len)
@@ -247,7 +244,7 @@ bool rcur_trim_if_char(struct rcur *rcur, char c)
 
         p = rcur_peek_remainder(rcur, &len);
         if (len > 0 && p[len-1] == c) {
-                rcur->p--;
+                rcur->len--;
                 return true;
         }
         return false;

--- a/src/rcur.c
+++ b/src/rcur.c
@@ -1,0 +1,254 @@
+#include "rcur.h"
+#include "ccan/utf8/utf8.h"
+#include "cursor.h"
+#include <errno.h>
+#include <string.h>
+
+/* Note that only rcur_pull and rcur_peek_remainder actually access
+ * rcur.  The rest are built on top of them! */
+
+/* Pull @len bytes from rcur, if space available.
+ * Return NULL if not valid.
+ */
+const void *rcur_pull(struct rcur *rcur, size_t len)
+{
+    const void *p = rcur_peek(rcur, len);
+    if (!p) {
+	rcur_fail(rcur);
+	return NULL;
+    }
+    rcur->p += len;
+    return rcur->p - len;
+}
+
+/* Access the remaining bytes.  Returns NULL and *len=0 if invalid. */
+const void *rcur_peek_remainder(const struct rcur *rcur, size_t *len)
+{
+    if (!rcur_valid(rcur)) {
+	*len = 0;
+	return NULL;
+    }
+    *len = rcur->end - rcur->p;
+    return rcur->p;
+}
+
+bool rcur_copy(struct rcur *rcur, void *dst, size_t len)
+{
+    const void *src = rcur_pull(rcur, len);
+    if (!src)
+	return false;
+    memcpy(dst, src, len);
+    return true;
+}
+
+/* Look ahead: returns NULL if @len too long.  Does *not* alter
+ * rcur */
+const void *rcur_peek(const struct rcur *rcur, size_t len)
+{
+    size_t actual_len;
+    const void *p = rcur_peek_remainder(rcur, &actual_len);
+
+    if (len > actual_len)
+	return NULL;
+    return p;
+}
+
+/* All these are based on rcur_pull. */
+bool rcur_skip(struct rcur *rcur, size_t len)
+{
+    return rcur_pull(rcur, len) != NULL;
+}
+
+unsigned char rcur_pull_byte(struct rcur *rcur)
+{
+    unsigned char v;
+
+    if (!rcur_copy(rcur, &v, sizeof(v)))
+	return 0;
+    return v;
+}
+
+uint16_t rcur_pull_u16(struct rcur *rcur)
+{
+    uint16_t v;
+
+    if (!rcur_copy(rcur, &v, sizeof(v)))
+	return 0;
+    return v;
+}
+
+uint32_t rcur_pull_u32(struct rcur *rcur)
+{
+    uint32_t v;
+
+    if (!rcur_copy(rcur, &v, sizeof(v)))
+	return 0;
+    return v;
+}
+
+uint64_t rcur_pull_varint(struct rcur *rcur)
+{
+    uint64_t v = 0;
+    unsigned char c;
+
+    for (size_t i = 0; i < 10; i++) { // Loop up to 10 bytes for 64-bit
+	c = rcur_pull_byte(rcur);
+	v |= ((uint64_t)c & 0x7F) << (i * 7);
+
+	if ((c & 0x80) == 0)
+	    break;
+    }
+    return v;
+}
+	
+uint32_t rcur_pull_varint_u32(struct rcur *rcur)
+{
+    uint64_t v = rcur_pull_varint(rcur);
+    if (v >= UINT32_MAX) {
+	rcur_fail(rcur);
+	v = 0;
+    }
+    return v;
+}
+
+size_t rcur_pull_whitespace(struct rcur *rcur)
+{
+    size_t len, wslen;
+    const unsigned char *c;
+
+    c = rcur_peek_remainder(rcur, &len);
+    for (wslen = 0; wslen < len; wslen++) {
+	if (!is_whitespace(c[wslen]))
+	    break;
+    }
+
+    rcur_skip(rcur, wslen);
+    return wslen;
+}
+
+// Returns 0 on error.  Adds length to *totlen.
+static uint32_t rcur_pull_utf8(struct rcur *rcur, size_t *totlen)
+{
+    struct utf8_state state = UTF8_STATE_INIT;
+
+    /* Since 0 is treated as a bad encoding, this terminated if we run
+     * out of chars */
+    while (!utf8_decode(&state, rcur_pull_byte(rcur)))
+	(*totlen)++;
+
+    if (errno != 0) {
+	rcur_fail(rcur);
+	return 0;
+    }
+    return state.c;
+}
+
+/* Remove is_punctuation(), return bytes removed */
+size_t rcur_pull_punctuation(struct rcur *rcur)
+{
+    size_t totlen = 0;
+
+    while (rcur_bytes_remaining(*rcur)) {
+	uint32_t c = rcur_pull_utf8(rcur, &totlen);
+	if (!is_punctuation(c))
+	    break;
+    }
+
+    if (!rcur_valid(rcur))
+	return 0;
+    return totlen;
+}
+
+/* Remove !is_alphanumeric(), return bytes removed */
+size_t rcur_pull_non_alphanumeric(struct rcur *rcur)
+{
+    size_t len, nonalpha_len;
+    const char *p = rcur_peek_remainder(rcur, &len);
+
+    for (nonalpha_len = 0; nonalpha_len < len; nonalpha_len++) {
+	if (!is_alphanumeric(p[nonalpha_len]))
+	    break;
+    }
+
+    rcur_skip(rcur, nonalpha_len);
+    return nonalpha_len;
+}
+
+const char *rcur_pull_word(struct rcur *rcur, size_t *len)
+{
+    const char *start = rcur_peek(rcur, 0);
+
+    /* consume_until_boundary */
+    *len = 0;
+    while (rcur_bytes_remaining(*rcur)) {
+	uint32_t c = rcur_pull_utf8(rcur, len);
+	if (!c || is_right_boundary(c))
+	    break;
+    }
+
+    if (!rcur_valid(rcur) || *len == 0)
+	return NULL;
+
+    return start;
+}
+
+const char *rcur_pull_c_string(struct rcur *rcur)
+{
+    size_t len;
+    const char *p = rcur_peek_remainder(rcur, &len);
+
+    for (size_t i = 0; i < len; i++) {
+	if (p[i] == '\0')
+	    return rcur_pull(rcur, i+1);
+    }
+    rcur_fail(rcur);
+    return NULL;
+}
+
+bool rcur_skip_if_match(struct rcur *rcur, const void *p, size_t len)
+{
+    const void *peek = rcur_peek(rcur, len);
+
+    if (!peek)
+	return false;
+
+    if (memcmp(p, peek, len) != 0)
+	return false;
+    rcur_skip(rcur, len);
+    return true;
+}
+
+bool rcur_skip_if_str_anycase(struct rcur *rcur, const char *str)
+{
+    size_t len = strlen(str);
+    const char *peek = rcur_peek(rcur, len);
+
+    if (!peek)
+	return false;
+
+    for (size_t i = 0; i < len; i++) {
+	if (tolower(peek[i]) != tolower(str[i]))
+	    return false;
+    }
+    rcur_skip(rcur, len);
+    return true;
+}
+
+const char *rcur_pull_prefixed_str(struct rcur *rcur, size_t *len)
+{
+    *len = rcur_pull_varint(rcur);
+    return rcur_pull(rcur, *len);
+}
+
+bool rcur_trim_if_char(struct rcur *rcur, char c)
+{
+        const char *p;
+        size_t len;
+
+        p = rcur_peek_remainder(rcur, &len);
+        if (len > 0 && p[len-1] == c) {
+                rcur->p--;
+                return true;
+        }
+        return false;
+}

--- a/src/rcur.h
+++ b/src/rcur.h
@@ -1,0 +1,164 @@
+/* A read-only cursor into a buffer.  You can pull as many times as you want,
+ * and check at the end if it is valid. */
+#ifndef JB55_RCUR_H
+#define JB55_RCUR_H
+
+#include "ccan/compiler/compiler.h"
+#include "ccan/likely/likely.h"
+#include "cursor.h"
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+struct rcur {
+    const unsigned char *start, *p, *end;
+};
+
+/* Is this valid?  Pulling too much (or invalid values) sets this true */
+static inline bool rcur_valid(const struct rcur *rcur)
+{
+    return unlikely(rcur->p != NULL);
+}
+
+static inline size_t rcur_bytes_remaining(struct rcur rcur)
+{
+    if (!rcur_valid(&rcur))
+        return 0;
+    return rcur.end - rcur.p;
+}
+
+/* Pull @len bytes from rcur, if space available.
+ * Return NULL if not valid.
+ */
+const void *rcur_pull(struct rcur *rcur, size_t len);
+
+/* Access the remaining bytes.  Returns NULL and *len=0 if invalid. */
+const void *rcur_peek_remainder(const struct rcur *rcur, size_t *len);
+
+/* Copy @len bytes from rcur, if space available.
+ * Return false if not valid.
+ */
+bool rcur_copy(struct rcur *rcur, void *dst, size_t len);
+
+/* Look ahead: returns NULL if @len too long.  Does *not* alter
+ * rcur */
+const void *rcur_peek(const struct rcur *rcur, size_t len);
+
+/* Mark this rcur invalid: return false for convenience. */
+static inline bool COLD rcur_fail(struct rcur *rcur)
+{
+    rcur->p = NULL;
+    return false;
+}
+
+/* Create rcur for buffer */
+static inline struct rcur rcur_forbuf(const void *buf, size_t len)
+{
+    struct rcur rcur;
+    rcur.start = buf;
+    rcur.end = buf + len;
+    rcur.p = buf;
+    return rcur;
+}
+
+/* Create rcur for string */
+static inline struct rcur rcur_forstr(const char *str)
+{
+    struct rcur rcur;
+    rcur.start = (const unsigned char *)str;
+    rcur.end = rcur.start + strlen(str);
+    rcur.p = rcur.start;
+    return rcur;
+}
+
+/* Create rcur for next len bytes in rcur */
+static inline struct rcur rcur_pull_slice(struct rcur *rcur, size_t len)
+{
+    struct rcur slice;
+
+    slice.start = slice.p = rcur_pull(rcur, len);
+    if (rcur_valid(&slice))
+	slice.end = slice.start + len;
+    else
+	slice.end = slice.start;
+    return slice;
+}
+
+/* Get rcur between these two: newer has been pulled from */
+static inline struct rcur rcur_between(const struct rcur *orig,
+                                       const struct rcur *newer)
+{
+    struct rcur rcur;
+    assert(newer->start == orig->start);
+
+    if (rcur_valid(newer)) {
+        assert(newer->p >= orig->p);
+        rcur = rcur_forbuf(orig->p, newer->p - orig->p);
+    } else {
+        rcur_fail(&rcur);
+    }
+    return rcur;
+}
+
+/* All these are based on rcur_pull. */
+bool rcur_skip(struct rcur *rcur, size_t len);
+unsigned char rcur_pull_byte(struct rcur *rcur);
+uint16_t rcur_pull_u16(struct rcur *rcur);
+uint32_t rcur_pull_u32(struct rcur *rcur);
+uint64_t rcur_pull_varint(struct rcur *rcur);
+uint32_t rcur_pull_varint_u32(struct rcur *rcur);
+
+/* Trim this character from the end of buffer, if present.  Returns
+ * true if trimmed. */
+bool rcur_trim_if_char(struct rcur *rcur, char c);
+
+/* Remove is_whitespace(), return bytes removed */
+size_t rcur_pull_whitespace(struct rcur *rcur);
+
+/* Remove is_punctuation(), return bytes removed */
+size_t rcur_pull_punctuation(struct rcur *rcur);
+
+/* Remove !is_alphanumeric(), return bytes removed */
+size_t rcur_pull_non_alphanumeric(struct rcur *rcur);
+
+/* Note: returns non-zero-terminated string, and sets len (or NULL) */
+const char *rcur_pull_prefixed_str(struct rcur *rcur, size_t *len);
+
+/* Returns up to next whitespace / punctuation.
+ * Returns NULL for invalid / at end. */
+const char *rcur_pull_word(struct rcur *rcur, size_t *len);
+
+/* Returns to \0 terminator.  NULL if invalid / at end */
+const char *rcur_pull_c_string(struct rcur *rcur);
+
+/* Skip over this if it matches.  Return true if skipped */
+bool rcur_skip_if_match(struct rcur *rcur, const void *p, size_t len);
+
+/* Skpi over if this matches string (case insentive) */
+bool rcur_skip_if_str_anycase(struct rcur *rcur, const char *str);
+
+/* FIXME: shim code */
+static inline struct cursor cursor_from_rcur(const struct rcur *rcur)
+{
+	struct cursor cur;
+
+	cur.start = (unsigned char *)rcur->start;
+	cur.end = (unsigned char *)rcur->end;
+	cur.p = (unsigned char *)rcur->p;
+
+	return cur;
+}
+
+static inline struct rcur rcur_from_cursor(const struct cursor *cur)
+{
+	struct rcur rcur;
+
+	rcur.start = cur->start;
+	rcur.end = cur->end;
+	rcur.p = cur->p;
+
+	return rcur;
+}
+#endif /* JB55_RCUR_H */

--- a/test.c
+++ b/test.c
@@ -169,6 +169,7 @@ static void test_invoice_encoding(const char *bolt11_str)
 	unsigned char buf[4096];
 	char *fail = NULL;
 	struct cursor cur;
+	struct rcur rcur;
 	struct ndb_invoice invoice;
 	struct bolt11 *bolt11;
 
@@ -177,8 +178,8 @@ static void test_invoice_encoding(const char *bolt11_str)
 
 	assert(fail == NULL);
 	assert(ndb_encode_invoice(&cur, bolt11));
-	cur.p = cur.start;
-	assert(ndb_decode_invoice(&cur, &invoice));
+	rcur = rcur_forbuf(cur.start, cur.end - cur.start);
+	assert(ndb_decode_invoice(&rcur, &invoice));
 
 	assert(bolt11->msat->millisatoshis == invoice.amount);
 	assert(bolt11->timestamp == invoice.timestamp);

--- a/test.c
+++ b/test.c
@@ -8,6 +8,7 @@
 #include "protected_queue.h"
 #include "memchr.h"
 #include "print_util.h"
+#include "rcur.h"
 #include "bindings/c/profile_reader.h"
 #include "bindings/c/profile_verifier.h"
 #include "bindings/c/meta_reader.h"


### PR DESCRIPTION
The result is cleaner, I think, but the transition is kinda painful! 

An `rcur` can be safely be pulled from indefinitely (giving zeros), and then at the end you can check if it was all OK.  This makes for very robust error handling, and if you want to peek, rather than pull, you can save and restore `rcur` easily (though we don't often do that!).

After this, I have a PR series which replaces the remaining cursor parts with `wbuf`.