### PR TITLE
ndb_filter_eq: filter equality testing

### DIFF
--- a/src/nostrdb.c
+++ b/src/nostrdb.c
@@ -2672,7 +2672,7 @@ ndb_filter_find_elements(struct ndb_filter *filter, enum ndb_filter_fieldtype ty
 	return NULL;
 }
 
-int ndb_filter_is_subset_of(struct ndb_filter *a, struct ndb_filter *b)
+int ndb_filter_is_subset_of(const struct ndb_filter *a, const struct ndb_filter *b)
 {
 	int i;
 	struct ndb_filter_elements *b_field, *a_field;
@@ -2700,20 +2700,22 @@ int ndb_filter_is_subset_of(struct ndb_filter *a, struct ndb_filter *b)
         // A is a subset of B because `k:1` and `a:b` both exist in A
 
 	for (i = 0; i < b->num_elements; i++) {
-		b_field = ndb_filter_get_elements(b, i);
-		a_field = ndb_filter_find_elements(a, b_field->field.type);
+		b_field = ndb_filter_get_elements((struct ndb_filter*)b, i);
+		a_field = ndb_filter_find_elements((struct ndb_filter*)a,
+						   b_field->field.type);
 
 		if (a_field == NULL)
 			return 0;
 
-		if (!ndb_filter_field_eq(a, a_field, b, b_field))
+		if (!ndb_filter_field_eq((struct ndb_filter*)a, a_field,
+					 (struct ndb_filter*)b, b_field))
 			return 0;
 	}
 
 	return 1;
 }
 
-int ndb_filter_eq(struct ndb_filter *a, struct ndb_filter *b)
+int ndb_filter_eq(const struct ndb_filter *a, const struct ndb_filter *b)
 {
 	int i;
 	struct ndb_filter_elements *a_els, *b_els;
@@ -2722,13 +2724,15 @@ int ndb_filter_eq(struct ndb_filter *a, struct ndb_filter *b)
 		return 0;
 
 	for (i = 0; i < a->num_elements; i++) {
-		a_els = ndb_filter_get_elements(a, i);
-		b_els = ndb_filter_find_elements(b, a_els->field.type);
+		a_els = ndb_filter_get_elements((struct ndb_filter*)a, i);
+		b_els = ndb_filter_find_elements((struct ndb_filter *)b,
+						 a_els->field.type);
 
 		if (b_els == NULL)
 			return 0;
 
-		if (!ndb_filter_field_eq(a, a_els, b, b_els))
+		if (!ndb_filter_field_eq((struct ndb_filter*)a, a_els,
+					 (struct ndb_filter*)b, b_els))
 			return 0;
 	}
 

--- a/src/nostrdb.c
+++ b/src/nostrdb.c
@@ -2600,7 +2600,7 @@ static int ndb_filter_group_add_filters(struct ndb_filter_group *group,
 
 
 static struct ndb_filter_elements *
-ndb_filter_get_elems(struct ndb_filter *filter, enum ndb_filter_fieldtype typ)
+ndb_filter_find_elements(struct ndb_filter *filter, enum ndb_filter_fieldtype typ)
 {
 	int i;
 	struct ndb_filter_elements *els;
@@ -2620,7 +2620,7 @@ static uint64_t *
 ndb_filter_get_elem(struct ndb_filter *filter, enum ndb_filter_fieldtype typ)
 {
 	struct ndb_filter_elements *els;
-	if ((els = ndb_filter_get_elems(filter, typ)))
+	if ((els = ndb_filter_find_elements(filter, typ)))
 		return &els->elements[0];
 	return NULL;
 }
@@ -2697,7 +2697,7 @@ static int ndb_query_plan_execute_ids(struct ndb_txn *txn,
 	matched = 0;
 	until = UINT64_MAX;
 
-	if (!(ids = ndb_filter_get_elems(filter, NDB_FILTER_IDS)))
+	if (!(ids = ndb_filter_find_elements(filter, NDB_FILTER_IDS)))
 		return 0;
 
 	if ((pint = ndb_filter_get_int(filter, NDB_FILTER_UNTIL)))
@@ -2874,7 +2874,7 @@ static int ndb_query_plan_execute_tags(struct ndb_txn *txn,
 
 	db = txn->lmdb->dbs[NDB_DB_NOTE_TAGS];
 
-	if (!(tags = ndb_filter_get_elems(filter, NDB_FILTER_TAGS)))
+	if (!(tags = ndb_filter_find_elements(filter, NDB_FILTER_TAGS)))
 		return 0;
 
 	until = UINT64_MAX;
@@ -2953,7 +2953,7 @@ static int ndb_query_plan_execute_kinds(struct ndb_txn *txn,
 	int i, rc;
 
 	// we should have kinds in a kinds filter!
-	if (!(kinds = ndb_filter_get_elems(filter, NDB_FILTER_KINDS)))
+	if (!(kinds = ndb_filter_find_elements(filter, NDB_FILTER_KINDS)))
 		return 0;
 
 	until = UINT64_MAX;
@@ -3010,10 +3010,10 @@ static enum ndb_query_plan ndb_filter_plan(struct ndb_filter *filter)
 {
 	struct ndb_filter_elements *ids, *kinds, *authors, *tags;
 
-	ids = ndb_filter_get_elems(filter, NDB_FILTER_IDS);
-	kinds = ndb_filter_get_elems(filter, NDB_FILTER_KINDS);
-	authors = ndb_filter_get_elems(filter, NDB_FILTER_AUTHORS);
-	tags = ndb_filter_get_elems(filter, NDB_FILTER_TAGS);
+	ids = ndb_filter_find_elements(filter, NDB_FILTER_IDS);
+	kinds = ndb_filter_find_elements(filter, NDB_FILTER_KINDS);
+	authors = ndb_filter_find_elements(filter, NDB_FILTER_AUTHORS);
+	tags = ndb_filter_find_elements(filter, NDB_FILTER_TAGS);
 
 	// this is rougly similar to the heuristic in strfry's dbscan
 	if (ids) {

--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -257,6 +257,9 @@ struct ndb_filter {
 	int current;
 
 	// struct ndb_filter_elements offsets into elem_buf
+	//
+	// TODO(jb55): this should probably be called fields. elements are
+	// the things within fields
 	int elements[NDB_NUM_FILTERS]; 
 };
 
@@ -492,6 +495,7 @@ int ndb_filter_init(struct ndb_filter *);
 int ndb_filter_add_id_element(struct ndb_filter *, const unsigned char *id);
 int ndb_filter_add_int_element(struct ndb_filter *, uint64_t integer);
 int ndb_filter_add_str_element(struct ndb_filter *, const char *str);
+int ndb_filter_eq(struct ndb_filter *, struct ndb_filter *);
 
 // filters from json
 int ndb_filter_from_json(const char *, int len, struct ndb_filter *filter, unsigned char *buf, int bufsize);

--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -495,10 +495,10 @@ int ndb_filter_init(struct ndb_filter *);
 int ndb_filter_add_id_element(struct ndb_filter *, const unsigned char *id);
 int ndb_filter_add_int_element(struct ndb_filter *, uint64_t integer);
 int ndb_filter_add_str_element(struct ndb_filter *, const char *str);
-int ndb_filter_eq(struct ndb_filter *, struct ndb_filter *);
+int ndb_filter_eq(const struct ndb_filter *, const struct ndb_filter *);
 
 /// is `a` a subset of `b`
-int ndb_filter_is_subset_of(struct ndb_filter *a, struct ndb_filter *b);
+int ndb_filter_is_subset_of(const struct ndb_filter *a, const struct ndb_filter *b);
 
 // filters from json
 int ndb_filter_from_json(const char *, int len, struct ndb_filter *filter, unsigned char *buf, int bufsize);

--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -497,6 +497,9 @@ int ndb_filter_add_int_element(struct ndb_filter *, uint64_t integer);
 int ndb_filter_add_str_element(struct ndb_filter *, const char *str);
 int ndb_filter_eq(struct ndb_filter *, struct ndb_filter *);
 
+/// is `a` a subset of `b`
+int ndb_filter_is_subset_of(struct ndb_filter *a, struct ndb_filter *b);
+
 // filters from json
 int ndb_filter_from_json(const char *, int len, struct ndb_filter *filter, unsigned char *buf, int bufsize);
 

--- a/test.c
+++ b/test.c
@@ -1662,8 +1662,36 @@ static void test_weird_note_corruption() {
 	ndb_destroy(ndb);
 }
 
+static void test_filter_eq() {
+	struct ndb_filter filter, *f = &filter;
+	struct ndb_filter filter2, *f2 = &filter2;
+
+	ndb_filter_init(f);
+	assert(ndb_filter_start_field(f, NDB_FILTER_UNTIL));
+	assert(ndb_filter_add_int_element(f, 42));
+	ndb_filter_end_field(f);
+	assert(ndb_filter_start_field(f, NDB_FILTER_KINDS));
+	assert(ndb_filter_add_int_element(f, 1));
+	assert(ndb_filter_add_int_element(f, 2));
+	ndb_filter_end_field(f);
+	ndb_filter_end(f);
+
+	ndb_filter_init(f2);
+	assert(ndb_filter_start_field(f2, NDB_FILTER_KINDS));
+	assert(ndb_filter_add_int_element(f2, 2));
+	assert(ndb_filter_add_int_element(f2, 1));
+	ndb_filter_end_field(f2);
+	assert(ndb_filter_start_field(f2, NDB_FILTER_UNTIL));
+	assert(ndb_filter_add_int_element(f2, 42));
+	ndb_filter_end_field(f2);
+	ndb_filter_end(f2);
+
+	assert(ndb_filter_eq(f, f2));
+}
+
 int main(int argc, const char *argv[]) {
 	test_parse_filter_json();
+	test_filter_eq();
 	test_filter_json();
 	test_bech32_parsing();
 	test_single_url_parsing();

--- a/test.c
+++ b/test.c
@@ -1689,9 +1689,45 @@ static void test_filter_eq() {
 	assert(ndb_filter_eq(f, f2));
 }
 
+static void test_filter_is_subset() {
+	struct ndb_filter global, *g = &global;
+	struct ndb_filter kind, *k = &kind;
+	struct ndb_filter kind_and_id, *ki = &kind_and_id;
+
+	const unsigned char id[] = {
+	  0x03, 0x36, 0x94, 0x8b, 0xdf, 0xbf, 0x5f, 0x93, 0x98, 0x02, 0xeb, 0xa0,
+	  0x3a, 0xa7, 0x87, 0x35, 0xc8, 0x28, 0x25, 0x21, 0x1e, 0xec, 0xe9, 0x87,
+	  0xa6, 0xd2, 0xe2, 0x0e, 0x3c, 0xff, 0xf9, 0x30
+	};
+
+	ndb_filter_init(g);
+	ndb_filter_end(g);
+
+	ndb_filter_init(k);
+	assert(ndb_filter_start_field(k, NDB_FILTER_KINDS));
+	assert(ndb_filter_add_int_element(k, 1));
+	ndb_filter_end_field(k);
+	ndb_filter_end(k);
+
+	ndb_filter_init(ki);
+	assert(ndb_filter_start_field(ki, NDB_FILTER_KINDS));
+	assert(ndb_filter_add_int_element(ki, 1));
+	ndb_filter_end_field(ki);
+	assert(ndb_filter_start_field(ki, NDB_FILTER_IDS));
+	assert(ndb_filter_add_id_element(ki, id));
+	ndb_filter_end_field(ki);
+	ndb_filter_end(ki);
+
+	assert(ndb_filter_is_subset_of(g, k) == 0);
+	assert(ndb_filter_is_subset_of(k, g) == 1);
+	assert(ndb_filter_is_subset_of(ki, k) == 1);
+	assert(ndb_filter_is_subset_of(k, ki) == 0);
+}
+
 int main(int argc, const char *argv[]) {
 	test_parse_filter_json();
 	test_filter_eq();
+	test_filter_is_subset();
 	test_filter_json();
 	test_bech32_parsing();
 	test_single_url_parsing();


### PR DESCRIPTION
I'm working on an algorithm for redundant filter pruning, and it needed filter equality testing. this adds that.