### PR TITLE
Make `struct ndb` threadsafe

### DIFF
--- a/src/nostrdb.c
+++ b/src/nostrdb.c
@@ -41,8 +41,7 @@
 #define MAX_FILTERS    16
 
 // the maximum size of inbox queues
-static const int DEFAULT_QUEUE_SIZE = 1000000;
-
+static const int DEFAULT_QUEUE_SIZE = 32768;
 
 // increase if we need bigger filters
 #define NDB_FILTER_PAGES 64
@@ -6654,7 +6653,7 @@ uint64_t ndb_subscribe(struct ndb *ndb, struct ndb_filter *filters, int num_filt
 		return 0;
 
 	// 500k ought to be enough for anyone
-	buflen = sizeof(uint64_t) * 65536;
+	buflen = sizeof(uint64_t) * DEFAULT_QUEUE_SIZE;
 	buf = malloc(buflen);
 
 	if (!prot_queue_init(&sub->inbox, buf, buflen, sizeof(uint64_t))) {

--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -530,7 +530,6 @@ int ndb_wait_for_notes(struct ndb *, uint64_t subid, uint64_t *note_ids, int not
 int ndb_poll_for_notes(struct ndb *, uint64_t subid, uint64_t *note_ids, int note_id_capacity);
 int ndb_unsubscribe(struct ndb *, uint64_t subid);
 int ndb_num_subscriptions(struct ndb *);
-struct ndb_filter *ndb_subscription_filters(struct ndb *, uint64_t subid, int *filters);
 
 // FULLTEXT SEARCH
 int ndb_text_search(struct ndb_txn *txn, const char *query, struct ndb_text_search_results *, struct ndb_text_search_config *);


### PR DESCRIPTION
The monitor and subscription access was technically not threadsafe. Let's fix that to avoid blowing our leg off in notecrumbs async rust land.