### PR TITLE
Only log to stdout if NDB_LOG is defined

### DIFF
--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -17,7 +17,7 @@
 
 //#define DEBUG 1
 
-#ifdef DEBUG
+#ifdef NDB_LOG
 #define ndb_debug(...) printf(__VA_ARGS__)
 #else
 #define ndb_debug(...) (void)0


### PR DESCRIPTION
The non-optional debugging to stdout is driving me crazy ...