### PR TITLE
bug: use indices[i] as index is not defined

### DIFF
--- a/src/nostrdb.c
+++ b/src/nostrdb.c
@@ -1512,7 +1512,7 @@ static int ndb_rebuild_note_indices(struct ndb_txn *txn, enum ndb_dbs *indices, 
 	// ensure they are all index dbs
 	for (i = 0; i < num_indices; i++) {
 		if (!ndb_db_is_index(indices[i])) {
-			fprintf(stderr, "ndb_rebuild_note_index: %s is not an index db\n", ndb_db_name(index));
+			fprintf(stderr, "ndb_rebuild_note_index: %s is not an index db\n", ndb_db_name(indices[i]));
 			return -1;
 		}
 	}


### PR DESCRIPTION
Use `indices[i]` as `index` is not defined, otherwise `make` fails with:

```
src/nostrdb.c:1515:83: error: variable 'index' is uninitialized when used here [-Werror,-Wuninitialized]
                        fprintf(stderr, "ndb_rebuild_note_index: %s is not an index db\n", ndb_db_name(index));
                                                                                                       ^~~~~
src/nostrdb.c:1507:2: note: variable 'index' is declared here
        enum ndb_dbs index;
        ^
1 error generated.
make: *** [src/nostrdb.o] Error 1
```