### PR TITLE
Implement nip50 fulltext searching

### DIFF
--- a/ndb.c
+++ b/ndb.c
@@ -240,7 +240,7 @@ int main(int argc, char *argv[])
 				ndb_filter_add_int_element(f, atoll(argv[1]));
 				argv += 2;
 				argc -= 2;
-			} else if (!strcmp(argv[0], "-l")) {
+			} else if (!strcmp(argv[0], "-l") || !strcmp(argv[0], "--limit")) {
 				limit = atol(argv[1]);
 				if (current_field) {
 					ndb_filter_end_field(f);

--- a/src/nostrdb.c
+++ b/src/nostrdb.c
@@ -2906,6 +2906,16 @@ ndb_filter_find_elements(struct ndb_filter *filter, enum ndb_filter_fieldtype ty
 	return NULL;
 }
 
+static const char *ndb_filter_find_search(struct ndb_filter *filter)
+{
+	struct ndb_filter_elements *els;
+
+	if (!(els = ndb_filter_find_elements(filter, NDB_FILTER_SEARCH)))
+		return NULL;
+
+	return ndb_filter_get_string_element(filter, els, 0);
+}
+
 int ndb_filter_is_subset_of(const struct ndb_filter *a, const struct ndb_filter *b)
 {
 	int i;

--- a/src/nostrdb.c
+++ b/src/nostrdb.c
@@ -3047,8 +3047,7 @@ static int query_is_full(struct ndb_query_results *results, int limit)
 static int ndb_query_plan_execute_ids(struct ndb_txn *txn,
 				      struct ndb_filter *filter,
 				      struct ndb_query_results *results,
-				      int limit
-				      )
+				      int limit)
 {
 	MDB_cursor *cur;
 	MDB_dbi db;
@@ -3908,9 +3907,10 @@ retry:
 		return 0;
 	}
 
-	if (last_result) {
-		if (last_result->key.note_id != result->key.note_id)
-			return 0;
+	// if the note id doesn't match the last result, then we stop trying
+	// each search word
+	if (last_result && last_result->key.note_id != result->key.note_id) {
+		return 0;
 	}
 
 	// On success, this could still be not related at all.

--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -156,6 +156,7 @@ enum ndb_filter_fieldtype {
 	NDB_FILTER_SINCE   = 5,
 	NDB_FILTER_UNTIL   = 6,
 	NDB_FILTER_LIMIT   = 7,
+	NDB_FILTER_SEARCH  = 8,
 };
 #define NDB_NUM_FILTERS 7
 

--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -545,6 +545,7 @@ int ndb_num_subscriptions(struct ndb *);
 
 // FULLTEXT SEARCH
 int ndb_text_search(struct ndb_txn *txn, const char *query, struct ndb_text_search_results *, struct ndb_text_search_config *);
+int ndb_text_search_with(struct ndb_txn *txn, const char *query, struct ndb_text_search_results *, struct ndb_text_search_config *, struct ndb_filter *filter);
 void ndb_default_text_search_config(struct ndb_text_search_config *);
 void ndb_text_search_config_set_order(struct ndb_text_search_config *, enum ndb_search_order);
 void ndb_text_search_config_set_limit(struct ndb_text_search_config *, int limit);

--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -314,6 +314,10 @@ struct ndb_text_search_key
 struct ndb_text_search_result {
 	struct ndb_text_search_key key;
 	int prefix_chars;
+
+	// This is only set if we passed a filter for nip50 searches
+	struct ndb_note *note;
+	uint64_t note_size;
 };
 
 struct ndb_text_search_results {

--- a/test.c
+++ b/test.c
@@ -1737,7 +1737,7 @@ static void test_filter_search()
 {
 	struct ndb_filter filter, *f = &filter;
 
-	assert(ndb_filter_init_with(f, 2));
+	assert(ndb_filter_init_with(f, 1));
 
 	assert(ndb_filter_start_field(f, NDB_FILTER_SEARCH));
 	assert(ndb_filter_add_str_element(f, "searchterm"));
@@ -1755,7 +1755,7 @@ static void test_filter_parse_search_json() {
 	struct ndb_filter filter, *f = &filter;
 	struct ndb_filter_elements *es;
 
-	ndb_filter_init_with(f, 2);
+	ndb_filter_init_with(f, 1);
 	assert(ndb_filter_from_json(json, strlen(json), f, buf, sizeof(buf)));
 	assert(filter.finalized);
 


### PR DESCRIPTION
This adds support for nip50 fulltext searches. This allows you to use
the nostrdb query interface for executing fulltext searches instead of
the typical `ndb_text_search` api. The benefits of this include a
standardized query interface that also further filters on other fields
in the filter.

I've updated ndb, so you can test via:

# Example query

Searching my notes from the local notedeck db with the text 'gm'

```shell
$ ndb -d ~/.local/share/notedeck/db query --until 1735401900 -a 32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245 --limit 2 --search 'gm' | jq .content
"gm. what's everyone up to today."
```
