### PR TITLE
Relay index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 tags
+build.log
+*.swp
 data.mdb
 lock.mdb
 v0-lock

--- a/TODO
+++ b/TODO
@@ -1,5 +1,0 @@
-subscription polling
-execution plan for created_at query
-note kind index rebuild migration
-(A) filter from json
-tags index migration

--- a/ndb.c
+++ b/ndb.c
@@ -22,6 +22,7 @@ static int usage()
 	printf("	print-search-keys\n");
 	printf("	print-kind-keys\n");
 	printf("	print-tag-keys\n");
+	printf("	print-relay-kind-index-keys\n");
 	printf("	import <line-delimited json file>\n\n");
 	printf("settings\n\n");
 	printf("	--skip-verification  skip signature validation\n");
@@ -98,6 +99,7 @@ static void print_stats(struct ndb_stat *stat)
 int ndb_print_search_keys(struct ndb_txn *txn);
 int ndb_print_kind_keys(struct ndb_txn *txn);
 int ndb_print_tag_index(struct ndb_txn *txn);
+int ndb_print_relay_kind_index(struct ndb_txn *txn);
 
 static void print_note(struct ndb_note *note)
 {
@@ -351,7 +353,11 @@ int main(int argc, char *argv[])
 		ndb_begin_query(ndb, &txn);
 		ndb_print_tag_index(&txn);
 		ndb_end_query(&txn);
-	}  else if (argc == 3 && !strcmp(argv[1], "profile")) {
+	} else if (argc == 2 && !strcmp(argv[1], "print-relay-kind-index-keys")) {
+		ndb_begin_query(ndb, &txn);
+		ndb_print_relay_kind_index(&txn);
+		ndb_end_query(&txn);
+	} else if (argc == 3 && !strcmp(argv[1], "profile")) {
 		pk_str = argv[2];
 		if (!hex_decode(pk_str, strlen(pk_str), tmp_id, sizeof(tmp_id))) {
 			fprintf(stderr, "failed to decode hex pubkey '%s'\n", pk_str);

--- a/src/nostrdb.c
+++ b/src/nostrdb.c
@@ -7176,6 +7176,28 @@ void ndb_config_set_ingest_filter(struct ndb_config *config,
 	config->filter_context = filter_ctx;
 }
 
+int ndb_print_relay_kind_index(struct ndb_txn *txn)
+{
+	MDB_cursor *cur;
+	MDB_val k, v;
+	int i;
+
+	if (mdb_cursor_open(txn->mdb_txn, txn->lmdb->dbs[NDB_DB_NOTE_RELAY_KIND], &cur))
+		return 0;
+
+	i = 1;
+	printf("relay\tkind\tcreated_at\tnote_id\n");
+	while (mdb_cursor_get(cur, &k, &v, MDB_NEXT) == 0) {
+		printf("%s\t", (const char *)(k.mv_data + 25));
+		printf("%" PRIu64 "\t", *(uint64_t*)(k.mv_data + 8));
+		printf("%" PRIu64 "\t", *(uint64_t*)(k.mv_data + 16));
+		printf("%" PRIu64 "\n", *(uint64_t*)(k.mv_data + 0));
+		i++;
+	}
+
+	return i;
+}
+
 int ndb_print_tag_index(struct ndb_txn *txn)
 {
 	MDB_cursor *cur;

--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -229,6 +229,13 @@ struct ndb_builder {
 	struct ndb_tag *current_tag;
 };
 
+struct ndb_note_relay_iterator {
+	struct ndb_txn *txn;
+	uint64_t note_key;
+	int cursor_op;
+	void *mdb_cur;
+};
+
 struct ndb_iterator {
 	struct ndb_note *note;
 	struct ndb_tag *tag;
@@ -609,6 +616,11 @@ uint16_t ndb_tag_count(struct ndb_tag *);
 int ndb_tags_iterate_next(struct ndb_iterator *iter);
 struct ndb_str ndb_iter_tag_str(struct ndb_iterator *iter, int ind);
 struct ndb_str ndb_tag_str(struct ndb_note *note, struct ndb_tag *tag, int ind);
+
+// RELAY ITER
+int ndb_note_relay_iterate_start(struct ndb_txn *txn, struct ndb_note_relay_iterator *iter, uint64_t note_key);
+const char *ndb_note_relay_iterate_next(struct ndb_note_relay_iterator *iter);
+void ndb_note_relay_iterate_close(struct ndb_note_relay_iterator *iter);
 
 // NAMES
 const char *ndb_db_name(enum ndb_dbs db);

--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -55,6 +55,11 @@ struct ndb_str {
 	};
 };
 
+struct ndb_ingest_meta {
+	unsigned client;
+	const char *relay;
+};
+
 struct ndb_keypair {
 	unsigned char pubkey[32];
 	unsigned char secret[32];
@@ -189,6 +194,8 @@ enum ndb_dbs {
 	NDB_DB_NOTE_TAGS,  // note tags index
 	NDB_DB_NOTE_PUBKEY, // note pubkey index
 	NDB_DB_NOTE_PUBKEY_KIND, // note pubkey kind index
+	NDB_DB_NOTE_RELAY_KIND, // relay+kind+created -> note_id
+	NDB_DB_NOTE_RELAYS, // note_id -> relays
 	NDB_DBS,
 };
 
@@ -470,14 +477,23 @@ int ndb_note_verify(void *secp_ctx, unsigned char pubkey[32], unsigned char id[3
 // NDB
 int ndb_init(struct ndb **ndb, const char *dbdir, const struct ndb_config *);
 int ndb_db_version(struct ndb_txn *txn);
+
+// NOTE PROCESSING
 int ndb_process_event(struct ndb *, const char *json, int len);
+void ndb_ingest_meta_init(struct ndb_ingest_meta *meta, unsigned client, const char *relay);
+// Process an event, recording the relay where it came from.
+int ndb_process_event_with(struct ndb *, const char *json, int len, struct ndb_ingest_meta *meta);
 int ndb_process_events(struct ndb *, const char *ldjson, size_t len);
+int ndb_process_events_with(struct ndb *ndb, const char *ldjson, size_t json_len, struct ndb_ingest_meta *meta);
 #ifndef _WIN32
 // TODO: fix on windows
 int ndb_process_events_stream(struct ndb *, FILE* fp);
 #endif
+// deprecated: use ndb_ingest_event_with
 int ndb_process_client_event(struct ndb *, const char *json, int len);
+// deprecated: use ndb_ingest_events_with
 int ndb_process_client_events(struct ndb *, const char *json, size_t len);
+
 int ndb_begin_query(struct ndb *, struct ndb_txn *);
 int ndb_search_profile(struct ndb_txn *txn, struct ndb_search *search, const char *query);
 int ndb_search_profile_next(struct ndb_search *search);
@@ -492,6 +508,7 @@ uint64_t ndb_get_profilekey_by_pubkey(struct ndb_txn *txn, const unsigned char *
 struct ndb_note *ndb_get_note_by_id(struct ndb_txn *txn, const unsigned char *id, size_t *len, uint64_t *primkey);
 struct ndb_note *ndb_get_note_by_key(struct ndb_txn *txn, uint64_t key, size_t *len);
 void *ndb_get_note_meta(struct ndb_txn *txn, const unsigned char *id, size_t *len);
+int ndb_note_seen_on_relay(struct ndb_txn *txn, uint64_t note_key, const char *relay);
 void ndb_destroy(struct ndb *);
 
 // BUILDER


### PR DESCRIPTION
commit 565e6895915d187fcbb9c05c90895dea4363b8f5
Author: William Casarin <jb55@jb55.com>
Date:   Wed Mar 19 15:12:52 2025 -0700

    Initial relay index implementation
    
    Add relay indexing for existing notes
    
    This patch introduces a relay index for new notes and notes that have
    already been stored, allowing the database to track additional relay
    sources for a given note.
    
    Changes:
    
    - Added `NDB_WRITER_NOTE_RELAY` to handle relay indexing separately from
      new note ingestion.
    
    - Implemented `ndb_write_note_relay()` and
      `ndb_write_note_relay_kind_index()` to store relay URLs.
    
    - Modified `ndb_ingester_process_event()` to check for existing notes
      and append relay info if necessary.
    
    - Introduced `ndb_note_has_relay()` to prevent duplicate relay entries.
    
    - Updated LMDB schema with `NDB_DB_NOTE_RELAYS` (note_id -> relay) and
      `NDB_DB_NOTE_RELAY_KIND` (relay + kind + created_at -> note).
    
    - Refactored `ndb_process_event()` to use `ndb_ingest_meta` for tracking
      relay sources.
    
    - Ensured proper memory management for relay strings in writer thread.
    
    With this change, nostrdb can better track where notes are seen across
    different relays, improving query capabilities for relay-based data
    retrieval.
    
    Signed-off-by: William Casarin <jb55@jb55.com>
