### PR TITLE
Relay queries

### DIFF
--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -162,6 +162,7 @@ enum ndb_filter_fieldtype {
 	NDB_FILTER_UNTIL   = 6,
 	NDB_FILTER_LIMIT   = 7,
 	NDB_FILTER_SEARCH  = 8,
+	NDB_FILTER_RELAYS  = 9,
 };
 #define NDB_NUM_FILTERS 7
 
@@ -564,6 +565,7 @@ struct ndb_filter_elements *ndb_filter_get_elements(const struct ndb_filter *, i
 int ndb_filter_start_field(struct ndb_filter *, enum ndb_filter_fieldtype);
 int ndb_filter_start_tag_field(struct ndb_filter *, char tag);
 int ndb_filter_matches(struct ndb_filter *, struct ndb_note *);
+int ndb_filter_matches_with_relay(struct ndb_filter *, struct ndb_note *, struct ndb_note_relay_iterator *iter);
 int ndb_filter_clone(struct ndb_filter *dst, struct ndb_filter *src);
 int ndb_filter_end(struct ndb_filter *);
 void ndb_filter_end_field(struct ndb_filter *);


### PR DESCRIPTION
Add support for relay-based filtering in nostr queries.

Filters can now include a "relays" field. Optimal performance when you include a kind as well:

```
{"relays":["wss://pyramid.fiatjaf.com/"], "kinds":[1]}
```

This corresponds to a `ndb` query like so:

```
$ ndb query -r wss://pyramid.fiatjaf.com/ -k 1 -l 1
using filter '{"relays":["wss://pyramid.fiatjaf.com/"],"kinds":[1],"limit":1}'
1 results in 0.094929 ms
{"id":"277dd4ed26d0b44576..}
```
