### PR TITLE
Custom filters

### DIFF
--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -2,6 +2,7 @@
 #define NOSTRDB_H
 
 #include <inttypes.h>
+#include <stdbool.h>
 #include "win.h"
 #include "cursor.h"
 
@@ -48,6 +49,7 @@ struct ndb_t {
 };
 
 struct ndb_str {
+	// NDB_PACKED_STR, NDB_PACKED_ID
 	unsigned char flag;
 	union {
 		const char *str;
@@ -163,8 +165,9 @@ enum ndb_filter_fieldtype {
 	NDB_FILTER_LIMIT   = 7,
 	NDB_FILTER_SEARCH  = 8,
 	NDB_FILTER_RELAYS  = 9,
+	NDB_FILTER_CUSTOM  = 10,
 };
-#define NDB_NUM_FILTERS 7
+#define NDB_NUM_FILTERS 10
 
 // when matching generic tags, we need to know if we're dealing with
 // a pointer to a 32-byte ID or a null terminated string
@@ -173,6 +176,7 @@ enum ndb_generic_element_type {
 	NDB_ELEMENT_STRING  = 1,
 	NDB_ELEMENT_ID      = 2,
 	NDB_ELEMENT_INT     = 3,
+	NDB_ELEMENT_CUSTOM  = 4,
 };
 
 enum ndb_search_order {
@@ -250,10 +254,18 @@ struct ndb_filter_string {
 	int len;
 };
 
+typedef bool ndb_filter_callback_fn(void *, struct ndb_note *);
+
+struct ndb_filter_custom {
+	void *ctx;
+	ndb_filter_callback_fn *cb;
+};
+
 union ndb_filter_element {
 	struct ndb_filter_string string;
 	const unsigned char *id;
 	uint64_t integer;
+	struct ndb_filter_custom custom_filter;
 };
 
 struct ndb_filter_field {
@@ -546,6 +558,7 @@ int ndb_filter_init_with(struct ndb_filter *filter, int pages);
 int ndb_filter_add_id_element(struct ndb_filter *, const unsigned char *id);
 int ndb_filter_add_int_element(struct ndb_filter *, uint64_t integer);
 int ndb_filter_add_str_element(struct ndb_filter *, const char *str);
+int ndb_filter_add_custom_filter_element(struct ndb_filter *filter, ndb_filter_callback_fn *cb, void *ctx);
 int ndb_filter_eq(const struct ndb_filter *, const struct ndb_filter *);
 
 /// is `a` a subset of `b`

--- a/test.c
+++ b/test.c
@@ -1958,15 +1958,13 @@ static void test_custom_filter()
 	ndb_default_config(&config);
 	assert(ndb_init(&ndb, test_dir, &config));
 
-	assert(ndb_filter_init(f));
-	assert(ndb_filter_start_field(f, NDB_FILTER_KINDS));
-	assert(ndb_filter_add_int_element(f, 1));
+	ndb_filter_init(f);
+	ndb_filter_start_field(f, NDB_FILTER_KINDS);
+	ndb_filter_add_int_element(f, 1);
 	ndb_filter_end_field(f);
-	ndb_filter_end(f);
 
-	assert(ndb_filter_init(f));
-	assert(ndb_filter_start_field(f, NDB_FILTER_CUSTOM));
-	assert(ndb_filter_add_custom_filter_element(f, only_threads_filter, NULL));
+	ndb_filter_start_field(f, NDB_FILTER_CUSTOM);
+	ndb_filter_add_custom_filter_element(f, only_threads_filter, NULL);
 	ndb_filter_end_field(f);
 	ndb_filter_end(f);
 


### PR DESCRIPTION
This PR adds "custom filter" functionality to ndb_filter. This allows you to include a custom callback function in a filter to add any custom filtering logic you want

# Motivation

Sometimes there is lots of data to scan through that has tags with a specific structure. For example, you might want to pull only root kind 1 threads. There is no concept of "negative queries" in nostr, where you look for the absence of some fields. Custom queries allows you to perform additional logic on the query to exclude things like kind1 thread replies.

See `only_threads_filter` in `test.c` for an example

