### PR TITLE
Add NIP-22 kind 1111 comment support. signed off by elsat -npub1zafcm…

### DIFF
--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -280,6 +280,7 @@ enum ndb_common_kind {
 	NDB_CKIND_LIST,
 	NDB_CKIND_LONGFORM,
 	NDB_CKIND_STATUS,
+	NDB_CKIND_COMMENT,
 	NDB_CKIND_COUNT, // should always be last
 };
 
@@ -760,6 +761,14 @@ uint16_t *ndb_note_flags(struct ndb_note *);
 int ndb_note_is_rumor(struct ndb_note *note);
 unsigned char *ndb_note_rumor_receiver_pubkey(struct ndb_note *note);
 unsigned char *ndb_note_rumor_giftwrap_id(struct ndb_note *note);
+
+struct ndb_note_reply {
+	unsigned char *root;
+	unsigned char *reply;
+	unsigned char *mention;
+};
+void ndb_note_get_reply(struct ndb_note *note, struct ndb_note_reply *reply);
+int ndb_note_reply_is_to_root(struct ndb_note_reply *reply);
 
 /// write the note as json to a buffer
 int ndb_note_json(struct ndb_note *, char *buf, int buflen);


### PR DESCRIPTION
## NIP-22 Kind 1111 (Comment) Support

Purely additive changes on master — no NIP-10 parsing refactor, no ABI-breaking enum reordering, no unrelated deletions. Single squashed commit.

### Addressing review feedback

> **jb55**: "this changes the nip10 parsing code which I copied from nostrdb-rs"

NIP-10 parsing logic is now **identical** to master — same `strcmp`-based marker check, same `str.flag == NDB_PACKED_STR` guard, same positional fallback. The only addition is an uppercase `E` tag handler *before* the existing `e` check, which `continue`s past the NIP-10 path entirely.

> **jb55**: "before we can change the reply parsing code we'll need to port the nip10 test coverage from rust first"

Done. 6 NIP-10 tests ported, matching the positional behavior of the current C implementation. 2 additional NIP-22 uppercase-E tests added.

> **jb55**: "no change that adds 1111 should effect the existing reply number assertions for kind1"

`test_count_metadata` assertions are **unchanged**: **83 direct / 93 thread** replies. The test database contains zero kind 1111 events, so counts are identical.

### Changes (3 files, +206 / -18)

- **`src/nostrdb.h`** — `NDB_CKIND_COMMENT` appended at end of enum (preserves ABI); `struct ndb_note_reply` + `ndb_note_get_reply` / `ndb_note_reply_is_to_root` exposed as public API
- **`src/nostrdb.c`** — Removed private struct (now in header); renamed `ndb_parse_reply` → `ndb_note_get_reply` and `ndb_is_reply_to_root` → `ndb_note_reply_is_to_root` (removed `static`); added NIP-22 uppercase `E` tag handler; kind 1111 in reply counting, fulltext indexing, kind mapping
- **`test.c`** — 8 new tests: 6 NIP-10 positional + 2 NIP-22 uppercase-E

### Test matrix

| Test | Scenario | Tags | Expected root | Expected reply | reply_to_root |
|------|----------|------|---------------|----------------|---------------|
| `test_nip10_deprecated` | 2 positional e-tags, no markers | `["e", A], ["e", B]` | A | B | no |
| `test_nip10_deprecated_reply_to_root` | Single positional e-tag | `["e", A]` | A | null | yes |
| `test_nip10_positional_two_tags_same_id` | 2 positional e-tags, same id | `["e", A], ["e", A]` | A | A | yes |
| `test_nip10_mixed_positional` | 3 positional e-tags | `["e", A], ["e", B], ["e", C]` | A | B | no |
| `test_nip22_uppercase_E_root` | E sets root, e becomes reply | `["E", A], ["e", B]` | A | B | no |
| `test_nip22_uppercase_E_only` | E tag only, no e tags | `["E", A]` | A | null | yes |
| `test_count_metadata` | Regression: kind 1 reply counts | (test database) | 83 direct | 93 thread | — |

### How to test

```bash
cd nostrdb
git submodule update --init deps/secp256k1
make clean && make check
```

Closes #92

Signed-off-by: alltheseas