### PR TITLE
Expand nostrdb docs & mdbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ ndb
 
 /target
 /Cargo.lock
+
+# mdBook output
+/book
+/docs/book/build

--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ at an existing relay database via `-d path/to/db`.
 - `docs/cli.md` – comprehensive CLI command reference.
 - `docs/bindings/index.md` – pointers for C, Rust, and Swift consumers.
 
+### Render the docs as a book
+
+The `docs/book` directory contains an [mdBook](https://rust-lang.github.io/mdBook/) configuration
+that stitches all documentation together into a browsable site:
+
+```bash
+cargo install mdbook        # once, if you don't already have it
+mdbook serve docs/book --open
+```
+
+The `serve` task watches for file changes and rebuilds automatically. Use `mdbook build docs/book`
+to emit static HTML under `docs/book/build/`.
+
 ## API
 
 The API is *very* unstable. nostrdb is in heavy development mode so don't

--- a/README.md
+++ b/README.md
@@ -18,6 +18,82 @@ as a C library into any application with full nostr query support.
 
 [1]: https://github.com/hoytech/strfry
 
+## Why nostrdb
+
+- Zero-copy note model backed by [LMDB](https://symas.com/lmdb/) so queries simply point at memory-mapped pages.
+- Custom metadata and block formats give O(1) access to note fields, reactions, and parsed blocks.
+- Built-in full text indexing plus CLI tooling (`ndb`) for ad-hoc inspection.
+- Ships as a portable static library (`libnostrdb.a`) with bindings for C, Rust, and Swift.
+- Focused on embeddability—drop it into a relay, client, or analytics pipeline.
+
+## Project status
+
+The API is **very unstable**. nostrdb is in heavy development mode so expect
+breaking changes between commits. Track higher level docs in `docs/` for the latest APIs.
+
+## Supported platforms & dependencies
+
+nostrdb targets modern Unix-like systems (Linux, macOS). Windows builds require additional
+work and are not covered by the default build. The repository vendors most dependencies but
+you still need a toolchain with:
+
+- A C11 compiler (tested with Clang 15+ and GCC 12+)
+- `make`, `pkg-config`, and standard build tools (autoconf/automake for secp256k1)
+- `curl` and `zstd` (used to download sample data)
+- Optional: `flatc`/`flatcc` if regenerating schema bindings, `nix` if using `shell.nix`
+
+Third-party libraries are fetched/built automatically:
+
+- [LMDB](https://github.com/LMDB/lmdb) (memory-mapped storage)
+- [libsecp256k1](https://github.com/bitcoin-core/secp256k1) (signature verification)
+- [flatcc](https://github.com/dvidelabs/flatcc) / [flatbuffers](https://github.com/google/flatbuffers) (schema tooling)
+- [ccan](https://github.com/rustyrussell/ccan) utilities
+
+## Quick start
+
+```bash
+git clone https://github.com/damus-io/nostrdb.git
+cd nostrdb
+# refresh vendored submodules (libsecp256k1)
+./devtools/refresh-submodules.sh deps/secp256k1
+
+# build the CLI + static library
+make ndb   # or simply `make` to build ndb, libnostrdb.a, and benchmarks
+```
+
+### Run the sanitizer-backed tests
+
+```bash
+make testdata/db/.dir        # ensures the temporary LMDB dir exists
+make test                    # builds with ASan/UBSan flags and runs ./test
+```
+
+### Import sample data and query
+
+```bash
+# Download fixtures (zstd archives are pulled from jb55.com CDN)
+make testdata/many-events.json
+
+# Create an empty LMDB environment in ./data (default) and ingest
+./ndb --skip-verification import testdata/many-events.json
+
+# Run a text search (newest first by default)
+./ndb query --search "nostrdb" --limit 5
+
+# Print global stats about the database
+./ndb stat
+```
+
+Extra fixtures are listed under `testdata/` (see Makefile targets). You can also point `ndb`
+at an existing relay database via `-d path/to/db`.
+
+### Where to go next
+
+- `docs/getting-started.md` – detailed environment setup, workflows, and a minimal C ingestion example.
+- `docs/architecture.md` – how LMDB, note blocks, metadata, and indexes fit together.
+- `docs/api.md` – tour of the public C API surfaces.
+- `docs/cli.md` – comprehensive CLI command reference.
+- `docs/bindings/index.md` – pointers for C, Rust, and Swift consumers.
 
 ## API
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,140 @@
+# API Tour
+
+This document summarizes the primary entry points exposed by `src/nostrdb.h`.
+It is not an exhaustive reference but should help you find the right family of
+functions for common tasks. See the header for full signatures and structure
+definitions.
+
+## Configuration & lifecycle
+
+```c
+struct ndb *db;
+struct ndb_config config;
+ndb_default_config(&config);
+ndb_config_set_mapsize(&config, 1ULL << 34); // 16 GiB
+ndb_config_set_flags(&config, NDB_FLAG_SKIP_NOTE_VERIFY);
+ndb_config_set_ingest_threads(&config, 4);
+ndb_config_set_ingest_filter(&config, my_filter, ctx);
+ndb_config_set_subscription_callback(&config, my_sub_cb, ctx);
+ndb_config_set_writer_scratch_buffer_size(&config, 4 * 1024 * 1024);
+
+if (!ndb_init(&db, "./data", &config)) { /* handle error */ }
+...
+ndb_destroy(db);
+```
+
+- `ndb_default_config` – zeroes + sensible defaults.
+- `ndb_config_set_*` – tune ingest threads, flags, LMDB map size, filters, subscription callbacks.
+- `ndb_init` – opens/creates the LMDB environment at `dbdir`. Always pair with `ndb_destroy`.
+
+## Ingestion helpers
+
+- `ndb_process_event`, `ndb_process_events` – parse nostr JSON (single event or LDJSON batch).
+- `ndb_process_event_with`, `ndb_process_events_with` – include relay/client metadata (`struct ndb_ingest_meta`).
+- `ndb_process_events_stream` – stream reader-friendly variant used by the CLI.
+- `ndb_ingest_meta_init` – convenience initializer for metadata.
+- `ndb_process_client_event(s)` – legacy wrappers (prefer the `ndb_process_event*` family).
+
+### Metadata builders
+
+Metadata is created/updated via `ndb_note_meta_builder`:
+
+```c
+unsigned char buf[1024];
+struct ndb_note_meta_builder builder;
+ndb_note_meta_builder_init(&builder, buf, sizeof buf);
+
+struct ndb_note_meta_entry *entry = ndb_note_meta_add_entry(&builder);
+ndb_note_meta_reaction_set(entry, /*count=*/5, reaction);
+
+struct ndb_note_meta *meta;
+ndb_note_meta_build(&builder, &meta);
+ndb_set_note_meta(db, note_id, meta);
+```
+
+Key functions:
+
+- `ndb_note_meta_builder_init`, `ndb_note_meta_builder_resized`, `ndb_note_meta_build`
+- `ndb_note_meta_add_entry`, `ndb_note_meta_builder_find_entry`
+- Accessors such as `ndb_note_meta_counts_*`, `ndb_note_meta_reaction_set`, `ndb_note_meta_flags`
+- `ndb_get_note_meta`, `ndb_note_meta_entries`, `ndb_note_meta_find_entry`
+
+## Transactions & queries
+
+Readers borrow LMDB transactions via `ndb_begin_query` / `ndb_end_query`.
+
+```c
+struct ndb_txn txn;
+if (!ndb_begin_query(db, &txn)) { /* handle error */ }
+
+struct ndb_filter filter;
+ndb_filter_init(&filter);
+ndb_filter_start_field(&filter, NDB_FILTER_KINDS);
+ndb_filter_add_int_element(&filter, 1);
+ndb_filter_end_field(&filter);
+ndb_filter_end(&filter);
+
+struct ndb_query_result results[32];
+int count = 0;
+ndb_query(&txn, &filter, 1, results, 32, &count);
+
+for (int i = 0; i < count; i++) {
+    struct ndb_note *note = results[i].note;
+    printf("kind=%u content=%.*s\n",
+           ndb_note_kind(note),
+           ndb_note_content_length(note),
+           ndb_note_content(note));
+}
+
+ndb_filter_destroy(&filter);
+ndb_end_query(&txn);
+```
+
+Notable APIs:
+
+- `ndb_filter_init`, `ndb_filter_init_with` – allocate filter buffers.
+- `ndb_filter_start_field`, `ndb_filter_start_tag_field`, `ndb_filter_add_*` – build queries.
+- `ndb_filter_matches*`, `ndb_filter_is_subset_of`, `ndb_filter_clone`, `ndb_filter_json`.
+- `ndb_filter_from_json` – decode NIP-01 filters.
+- `ndb_query` – execute filter arrays.
+- `ndb_subscribe`, `ndb_wait_for_notes`, `ndb_poll_for_notes`, `ndb_unsubscribe` – pub/sub APIs driven by ingest callbacks.
+
+### Text search
+
+- `ndb_text_search` / `ndb_text_search_with` – ranked searches over `NDB_DB_NOTE_TEXT`.
+- `ndb_default_text_search_config`, `ndb_text_search_config_set_order`, `ndb_text_search_config_set_limit` – configure sort order and result caps.
+
+## Profiles, relays, and helpers
+
+- `ndb_search_profile`, `ndb_search_profile_next`, `ndb_search_profile_end` – profile text search.
+- `ndb_get_profile_by_pubkey`, `ndb_get_profile_by_key`, `ndb_get_profilekey_by_pubkey` – profile cache access.
+- `ndb_get_notekey_by_id`, `ndb_get_note_by_id`, `ndb_get_note_by_key` – note lookups.
+- `ndb_note_seen_on_relay`, `ndb_note_relay_iterate_start`, `ndb_note_relay_iterate_next` – relay tracking.
+- `ndb_write_last_profile_fetch`, `ndb_read_last_profile_fetch` – per-pubkey sync bookkeeping.
+
+Helper utilities:
+
+- `ndb_create_keypair`, `ndb_decode_key`, `ndb_sign_id`, `ndb_calculate_id`, `ndb_note_verify`
+- `ndb_parse_content`, `ndb_blocks_iterate_*`, `ndb_blocks_free` – block parser helpers for rendering.
+
+## Note & tag inspection
+
+Once you have `struct ndb_note *` pointers:
+
+- `ndb_note_id`, `ndb_note_pubkey`, `ndb_note_sig`, `ndb_note_kind`, `ndb_note_created_at`
+- `ndb_note_content`, `ndb_note_content_length`, `ndb_note_json`
+- `ndb_note_tags`, `ndb_tags_iterate_start`, `ndb_tags_iterate_next`, `ndb_iter_tag_str`
+- `ndb_note_meta_iterator`, `ndb_note_meta_entry_at`, `ndb_note_meta_reaction_str`
+
+These functions operate on the packed, zero-copy note representation without heap
+allocations.
+
+## Error handling tips
+
+- Most APIs return `int` (non-zero success). Check return codes and call
+  `ndb_destroy` on failure to release LMDB handles.
+- Filters must be finalized with `ndb_filter_end` before calling `ndb_query`.
+- Reader transactions must be closed (`ndb_end_query`) before destroying the DB.
+
+For deeper explanations of the storage layers see `docs/architecture.md`. For CLI
+examples and manual test workflows refer to `docs/cli.md` and `docs/getting-started.md`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,124 @@
+# Architecture
+
+nostrdb is an embeddable storage engine tailored for nostr events. It adopts the
+LMDB single-writer/multi-reader model and layers a custom in-memory note format,
+metadata tables, and indexes on top of LMDB key/value pairs. This document
+summarizes the moving pieces so you can reason about performance and extend the
+system safely.
+
+## High-level data flow
+
+```
+ JSON event --> parser/builder --> packed note + metadata --> LMDB buckets
+                                                   |
+                                    derived indexes (tags, relays, text, ...)
+```
+
+1. **Ingestion** – `ndb_process_event*` (see `src/nostrdb.c`) parses JSON into
+   a compact `struct ndb_note` using cursor-backed builders (`struct ndb_builder`
+   in `src/nostrdb.h`). Optional ingest metadata (relay, client) gets recorded.
+2. **Validation** – Signatures are checked via `libsecp256k1` unless
+   `NDB_FLAG_SKIP_NOTE_VERIFY` is set in the config.
+3. **Persistence** – The packed note, associated metadata (`struct ndb_note_meta`),
+   and derived indexes are written into an LMDB environment using the single writer thread.
+4. **Query** – Readers open LMDB read transactions (`struct ndb_txn`), memory-map note
+   blobs, and evaluate filters or full-text queries without copying data out of LMDB.
+
+## LMDB layout
+
+The database uses multiple LMDB databases (`enum ndb_dbs` in `src/nostrdb.h`), the most
+important being:
+
+- `NDB_DB_NOTE` – primary storage for packed notes
+- `NDB_DB_META` – note metadata (reactions, counts)
+- `NDB_DB_PROFILE` / `NDB_DB_PROFILE_PK` – cached profiles and pubkey index
+- `NDB_DB_NOTE_TEXT` – full-text search index
+- `NDB_DB_NOTE_KIND`, `NDB_DB_NOTE_TAGS`, `NDB_DB_NOTE_PUBKEY[_KIND]` – secondary indexes
+- `NDB_DB_NOTE_RELAYS` / `NDB_DB_NOTE_RELAY_KIND` – relay tracking
+
+All buckets live inside the same LMDB environment and benefit from LMDB’s MVCC
+semantics: readers see a consistent view, the single writer thread avoids locks, and
+data is accessed by memory-mapping the LMDB pages.
+
+## Packed notes & metadata
+
+`struct ndb_note` packs the event ID, pubkey, signature, created-at, kind, tags, and
+content into cursor-managed buffers (see `struct ndb_builder`). Strings are either
+zero-copy references or 32-byte IDs flagged with `NDB_PACKED_STR`/`NDB_PACKED_ID`.
+
+Metadata lives alongside the note as a table of 16-byte entries
+(`struct ndb_note_meta_entry`, documented in `docs/metadata.md`). Each entry stores:
+
+- a type (counts, reactions, thread state, custom odd-numbered tags)
+- an 8-byte payload (counts or offsets into a data table)
+- optional aux data (e.g., total reaction counts)
+
+The format keeps frequently updated counters (direct replies, quotes, reactions)
+in-place, enabling atomic updates without decoding/recoding blobs.
+
+## Ingestion pipeline
+
+1. **Parsing** – Notes are parsed via `ndb_note_from_json` or the CLI’s streaming
+   helpers. The parser feeds an `ndb_builder` that writes into scratch buffers sized
+   by `ndb_config_set_writer_scratch_buffer_size`.
+2. **Filtering** – `ndb_config_set_ingest_filter` allows applications to inspect
+   notes before they hit disk (accept/reject/skip validation).
+3. **Metadata augmentation** – Reactions, relay sightings, and thread stats are
+   updated via metadata builder helpers (`ndb_note_meta_builder_*`).
+4. **Index maintenance** – As the single writer thread commits, it updates the
+   secondary indexes (tag, relay, kind, pubkey, full-text) and persists metadata.
+
+Because LMDB enforces a single writer, nostrdb runs the ingestion path on a
+dedicated thread. Reader-heavy workloads scale because reads are lock-free and
+operate on memory-mapped pages.
+
+## Query path
+
+Readers call `ndb_begin_query` to open an LMDB read transaction and construct one
+or more filters (`struct ndb_filter`). Filters can match IDs, authors, kinds,
+tags (`#e`, `#p`, custom), time ranges, search tokens, relays, or custom callbacks.
+
+`ndb_query` takes a filter array, executes it against indexes, and returns a list
+of `struct ndb_query_result` entries with direct `struct ndb_note *` pointers; no
+copying occurs because LMDB pages remain mapped for the lifetime of the transaction.
+
+Full-text searches (`ndb_text_search*`) use the same reader transactions but consult
+`NDB_DB_NOTE_TEXT` for ranked matches. Results can be fed through filters to enforce
+kind/author/relay constraints.
+
+## Blocks, content parsing, and relays
+
+`src/content_parser.c` and related block structures (`struct ndb_blocks`,
+`struct ndb_block_iterator`) parse note content into blocks (text, mentions,
+invoices, bech32 references) for rich rendering. Parsed blocks are cached in
+`NDB_DB_NOTE_BLOCKS` to avoid reparsing long-form notes.
+
+Relays are tracked with iterators (`struct ndb_note_relay_iterator`) that read from
+`NDB_DB_NOTE_RELAYS` and can be used both by the CLI (`ndb note-relays`) and
+embedders implementing gossip logic.
+
+## CLI + bindings
+
+The `ndb` CLI (`ndb.c`) exercises each subsystem:
+
+- `stat` – reads global LMDB stats (`ndb_stat`)
+- `query` – builds filters from CLI flags and prints JSON notes
+- `import` – streams line-delimited JSON into `ndb_process_events`
+- `profile`, `note-relays`, `print-*` – showcase profile cache, relay iterators,
+  search indexes, and metadata printing helpers
+
+Bindings in `src/bindings/{c,rust,swift}` expose the same primitives to higher-level
+languages. They are generated from `schemas/*.fbs` via `flatcc`/`flatc`.
+
+## Extending nostrdb safely
+
+- Prefer new LMDB buckets over overloading existing ones; update `enum ndb_dbs` and
+  provide readable names via `ndb_db_name`.
+- Keep ingestion work inside the writer thread. Use metadata builders for counters to
+  avoid race conditions.
+- Ensure filters are always finalized (`ndb_filter_end`) before executing queries.
+- When adjusting metadata formats, bump version fields in `struct ndb_note_meta` so
+  older readers can detect incompatibilities.
+
+For concrete API references, see `docs/api.md`. For CLI usage patterns, refer to
+`docs/cli.md`.

--- a/docs/bindings/index.md
+++ b/docs/bindings/index.md
@@ -1,0 +1,84 @@
+# Language Bindings
+
+nostrdb ships generated bindings for C (flatcc), Rust, and Swift to help
+integrate metadata/profile schemas into higher-level applications. All bindings
+live under `src/bindings/` and are regenerated from `schemas/*.fbs`.
+
+| Language | Location | Status | Notes |
+| --- | --- | --- | --- |
+| C | `src/bindings/c/*.h` | Stable | FlatCC-generated builders/readers for profile + metadata schemas |
+| Rust | `src/bindings/rust/*.rs` | Experimental | Plain module files suitable for inclusion in a workspace |
+| Swift | `src/bindings/swift/*.swift` | Experimental | Swift structs/enums emitted by `flatc` |
+
+## Regenerating bindings
+
+```bash
+# Generate everything
+make bindings
+
+# or target a single language
+make bindings-c
+make bindings-rust
+make bindings-swift
+```
+
+The `Makefile` invokes `flatcc` for C headers and `flatc` for Rust/Swift. Ensure
+both tools are installed (they are included in `shell.nix`).
+
+## C bindings
+
+Files:
+
+- `flatbuffers_common_{builder,reader}.h`
+- `profile_{builder,reader,verifier,json_parser}.h`
+- `meta_{builder,reader,verifier,json_parser}.h`
+
+Usage tips:
+
+- Include the headers alongside `nostrdb.h` and link against the libflatcc runtime.
+- Builders let you emit profile/metadata objects that match `ndb_profile` or
+  `ndb_meta` flatbuffers; readers help decode cached blobs from LMDB.
+- The CLI’s `profile` command shows the raw flatbuffer output you can feed into
+  these readers.
+
+Example:
+
+```c
+#include "src/bindings/c/profile_reader.h"
+
+void dump_profile(const void *buf) {
+    if (!ndb_profile_verify_as_root(buf, 1024)) return;
+    const struct ndb_Profile_table *profile = ndb_Profile_as_root(buf);
+    printf("name=%s\n", ndb_Profile_name(profile));
+}
+```
+
+## Rust bindings
+
+Files: `src/bindings/rust/ndb_profile.rs`, `src/bindings/rust/ndb_meta.rs`.
+
+- Generated with `flatc --rust`.
+- The modules use the `flatbuffers` crate’s runtime traits; add `flatbuffers = "23"`
+  (or compatible) to your `Cargo.toml`.
+- Include them in your crate via `mod ndb_profile;` / `mod ndb_meta;` and re-export
+  types as needed.
+- Pair them with FFI bindings to the core C API (e.g., via `bindgen`) for a
+  full Rust client.
+
+## Swift bindings
+
+Files: `src/bindings/swift/NdbProfile.swift`, `src/bindings/swift/NdbMeta.swift`.
+
+- Generated with `flatc --swift`.
+- Designed to drop into an Xcode project or Swift Package.
+- You will still interact with the C library via a bridging header or module map
+  (e.g., `module nostrdb`); the Swift bindings only cover the FlatBuffers data.
+
+## Versioning considerations
+
+- Regenerate bindings whenever `schemas/*.fbs` change to keep readers/builders in
+  sync with the on-disk data.
+- Track the nostrdb commit hash alongside the generated files in downstream
+  projects to avoid schema mismatches.
+- If you add new schemas, update the `Makefile` rules and this document so the
+  tooling remains discoverable.

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -1,0 +1,21 @@
+[book]
+title = "nostrdb Docs"
+authors = ["nostrdb maintainers"]
+description = "Architecture, API, and CLI docs for nostrdb"
+language = "en"
+multilingual = false
+src = "src"
+
+[build]
+build-dir = "build"
+create-missing = true
+
+[output.html]
+default-theme = "light"
+additional-css = []
+
+[output.html.fold]
+enabled = true
+
+[output.html.playground]
+enabled = false

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -1,0 +1,9 @@
+# Summary
+
+- [Introduction](introduction.md)
+- [Getting Started](getting-started.md)
+- [Architecture](architecture.md)
+- [API Tour](api.md)
+- [CLI Guide](cli.md)
+- [Metadata](metadata.md)
+- [Language Bindings](bindings.md)

--- a/docs/book/src/api.md
+++ b/docs/book/src/api.md
@@ -1,0 +1,1 @@
+{{#include ../api.md}}

--- a/docs/book/src/api.md
+++ b/docs/book/src/api.md
@@ -1,1 +1,1 @@
-{{#include ../api.md}}
+{{#include ../../api.md}}

--- a/docs/book/src/architecture.md
+++ b/docs/book/src/architecture.md
@@ -1,1 +1,1 @@
-{{#include ../architecture.md}}
+{{#include ../../architecture.md}}

--- a/docs/book/src/architecture.md
+++ b/docs/book/src/architecture.md
@@ -1,0 +1,1 @@
+{{#include ../architecture.md}}

--- a/docs/book/src/bindings.md
+++ b/docs/book/src/bindings.md
@@ -1,0 +1,1 @@
+{{#include ../bindings/index.md}}

--- a/docs/book/src/bindings.md
+++ b/docs/book/src/bindings.md
@@ -1,1 +1,1 @@
-{{#include ../bindings/index.md}}
+{{#include ../../bindings/index.md}}

--- a/docs/book/src/cli.md
+++ b/docs/book/src/cli.md
@@ -1,0 +1,1 @@
+{{#include ../cli.md}}

--- a/docs/book/src/cli.md
+++ b/docs/book/src/cli.md
@@ -1,1 +1,1 @@
-{{#include ../cli.md}}
+{{#include ../../cli.md}}

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -1,0 +1,1 @@
+{{#include ../getting-started.md}}

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -1,1 +1,1 @@
-{{#include ../getting-started.md}}
+{{#include ../../getting-started.md}}

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -1,0 +1,19 @@
+# Introduction
+
+nostrdb is an embeddable, LMDB-backed datastore for nostr events. This book stitches
+together the project’s reference material so you can explore the storage design,
+apis, and tooling without bouncing between Markdown files.
+
+Use the chapters in the navigation sidebar to jump into the topic you need:
+
+- **Getting Started**: prepare a development environment, build binaries, run tests, and
+  ingest fixtures.
+- **Architecture**: learn how packed notes, metadata tables, and LMDB buckets fit
+  together.
+- **API Tour**: browse the major public entry points in `src/nostrdb.h`.
+- **CLI Guide**: discover everything the `ndb` tool can do.
+- **Metadata**: deep dive into the note metadata format.
+- **Language Bindings**: regenerate and consume the generated C/Rust/Swift bindings.
+
+The book sources reuse the Markdown files stored under `docs/`, so contributions to
+those files automatically appear here as well.

--- a/docs/book/src/metadata.md
+++ b/docs/book/src/metadata.md
@@ -1,0 +1,1 @@
+{{#include ../metadata.md}}

--- a/docs/book/src/metadata.md
+++ b/docs/book/src/metadata.md
@@ -1,1 +1,1 @@
-{{#include ../metadata.md}}
+{{#include ../../metadata.md}}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,113 @@
+# `ndb` CLI Guide
+
+`ndb` is a thin CLI wrapper around the nostrdb library. It is useful for smoke
+tests, debugging indexes, and inspecting fixtures. Build it with `make ndb`
+(or plain `make`) and run the binary from the repo root.
+
+```
+usage: ndb [--skip-verification] [-d db_dir] <command>
+```
+
+- `--skip-verification` – disables signature checks during ingestion (often used
+  with fixtures or during development).
+- `-d <db_dir>` – points the CLI at a specific LMDB environment (defaults to `.`).
+
+## Commands
+
+### `stat`
+
+Prints per-database counts and byte usage (`ndb_stat`). Useful for monitoring
+index growth and verifying compaction.
+
+### `query`
+
+Executes an NIP-01 style filter. Options can be combined; most flags accept
+multiple occurrences.
+
+| Option | Description |
+| --- | --- |
+| `-k`, `--kind <int>` | Add a `kinds` entry |
+| `-a`, `--author <hex>` | Add an author pubkey |
+| `-i`, `--id <hex>` | Exact note IDs |
+| `-e <hex>` | `#e` tag references |
+| `-q <hex>` | `#q` tag references |
+| `-t <value>` | `#t` tag (string) |
+| `--relay`, `-r <url>` | Relay filter |
+| `--search`, `-S <term>` | Full-text query string |
+| `--since`, `-s <unix>` | Lower bound timestamp |
+| `--until`, `-u <unix>` | Upper bound timestamp |
+| `--limit`, `-l <n>` | Max results |
+| `--notekey <u64>` | Direct note primary key lookup (bypasses filters) |
+
+Examples:
+
+```bash
+# Latest text notes containing "nostrdb"
+./ndb query --kind 1 --search nostrdb --limit 5
+
+# Notes from one author referencing a thread id
+./ndb query --author deadbeef... --e cafebabe... --limit 20
+
+# Time-bounded relay-specific query
+./ndb query --relay wss://relay.damus.io --kind 1 --since 1700000000 --until 1700100000
+```
+
+> **Note:** Older help text mentions a `search` command. The current binary
+> implements full-text search via `query --search ...`.
+
+### `import <path|-`
+
+Imports line-delimited JSON. Pass `-` to read from stdin. Combine with
+`--skip-verification` during local testing:
+
+```bash
+./ndb --skip-verification import testdata/many-events.json
+```
+
+### `profile <hex-pubkey>`
+
+Looks up a cached profile, prints the raw flatbuffer payload in hex, and emits
+the profile database key to stderr. Handy for verifying profile syncs.
+
+### `note-relays <hex-note-id>`
+
+Translates a note ID into its LMDB key and prints every relay that has delivered
+that note. The command relies on `ndb_note_relay_iterator`.
+
+### `print-note-metadata`
+
+Walks every note’s metadata table and prints entries — useful for debugging
+reaction counts and thread stats. Combined with scripts you can analyze reaction
+distributions.
+
+### Index debug helpers
+
+Each helper opens a read transaction and dumps raw index keys:
+
+- `print-search-keys`
+- `print-kind-keys`
+- `print-tag-keys`
+- `print-relay-kind-index-keys`
+- `print-author-kind-index-keys`
+
+## Typical workflows
+
+1. **Bootstrap database**
+   ```bash
+   make testdata/many-events.json
+   ./ndb --skip-verification import testdata/many-events.json
+   ./ndb stat
+   ```
+2. **Inspect a failing query**
+   ```bash
+   ./ndb query --kind 1 --author deadbeef...
+   ./ndb print-tag-keys | head
+   ```
+3. **Validate relay coverage**
+   ```bash
+   ./ndb note-relays <note-id-hex>
+   ```
+
+Use `strace`, `perf`, or `valgrind` around these commands if you need deeper
+diagnostics. For more automation, script around `ndb` by reading/writing JSON on
+stdin/stdout.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,164 @@
+# Getting Started
+
+This guide walks through preparing a development environment, building the
+library/CLI, loading the provided fixtures, and embedding nostrdb from C.
+
+## 1. Prerequisites
+
+nostrdb is developed primarily on Linux and macOS. You will need:
+
+- A modern C11 compiler (GCC ≥12 or Clang ≥15 recommended)
+- `make`, `pkg-config`, `git`, `curl`, and `zstd`
+- Autotools (`autoconf`, `automake`, `libtool`) for building `libsecp256k1`
+- Optional: [`nix`](https://nixos.org/) to reuse `shell.nix`, `flatc`/`flatcc` when regenerating schema bindings, and `perf` for profiling
+
+The repository vendors most third-party sources (LMDB, flatcc, ccan) and ships a helper
+script for refreshable submodules.
+
+```bash
+git clone https://github.com/damus-io/nostrdb.git
+cd nostrdb
+./devtools/refresh-submodules.sh deps/secp256k1
+```
+
+If you use Nix, run `nix-shell` to drop into an environment with the required toolchain.
+
+## 2. Building
+
+The default `make` target builds everything: the `ndb` CLI, `libnostrdb.a`, and
+benchmarks. Common targets:
+
+| Command | Purpose |
+| --- | --- |
+| `make ndb` | Build only the CLI |
+| `make lib` | Build `libnostrdb.a` for embedding |
+| `make bench` | Build the ingestion benchmark |
+| `make run-bench` | Build fixtures and run the benchmark |
+| `make clean` | Remove binaries/objects |
+| `make distclean` | Also wipe downloaded deps |
+
+The build automatically downloads LMDB/flatcc archives and compiles
+`deps/secp256k1/.libs/libsecp256k1.a`. If that step fails, ensure autotools are
+installed and rerun `./devtools/refresh-submodules.sh deps/secp256k1`.
+
+### Sanitized tests
+
+`make test` compiles the `test` binary with ASan/UBSan (see `Makefile:194-197`) and
+places LMDB scratch data in `testdata/db/`. Run it regularly while making changes:
+
+```bash
+make testdata/db/.dir   # first time only
+make test
+```
+
+### Sample data + CLI smoke test
+
+```bash
+# Download and inflate fixture sets (stored in testdata/)
+make testdata/many-events.json
+
+# Populate an empty LMDB environment (default dir: ./data)
+./ndb --skip-verification import testdata/many-events.json
+
+# Run a few commands
+./ndb stat
+./ndb query --search "nostrdb" --limit 5
+./ndb profile <hex-pubkey>
+```
+
+Fixtures can also be streamed via `./ndb import -` if you pipe events from another
+process.
+
+## 3. Repository layout refresher
+
+- `src/` – core library plus bindings (`src/bindings/{c,rust,swift}`)
+- `docs/` – conceptual and reference material (what you're reading)
+- `testdata/` – sample LMDB environments and JSON fixtures
+- `schemas/` – flatbuffers definitions for metadata/profile data
+- `devtools/` – helper scripts (e.g., `refresh-submodules.sh`)
+- `shell.nix` – reproducible dev environment
+
+## 4. Minimal C ingestion example
+
+The snippet below opens a database, ingests a single event with verification disabled,
+and executes a simple kind filter. Replace the abbreviated hex strings with valid
+64-character nostr IDs/signatures/pubkeys before running it. Use it as a template for
+experiments or integration tests.
+
+```c
+#include "nostrdb.h"
+#include <stdio.h>
+#include <string.h>
+
+int main(void) {
+    struct ndb *ndb;
+    struct ndb_config config;
+    ndb_default_config(&config);
+    ndb_config_set_flags(&config, NDB_FLAG_SKIP_NOTE_VERIFY); // sample data only
+    ndb_config_set_mapsize(&config, 4ULL * 1024 * 1024 * 1024); // 4 GiB
+
+    if (!ndb_init(&ndb, "./data", &config)) {
+        fprintf(stderr, "failed to init nostrdb\n");
+        return 1;
+    }
+
+    const char *event =
+        "{\"id\":\"5d...\","
+        "\"pubkey\":\"ab...\","
+        "\"created_at\":1700000000,"
+        "\"kind\":1,"
+        "\"tags\":[],"
+        "\"content\":\"hello nostrdb\","
+        "\"sig\":\"cd...\"}";
+
+    if (!ndb_process_event(ndb, event, (int)strlen(event))) {
+        fprintf(stderr, "failed to ingest event\n");
+        ndb_destroy(ndb);
+        return 1;
+    }
+
+    struct ndb_filter filter;
+    ndb_filter_init(&filter);
+    ndb_filter_start_field(&filter, NDB_FILTER_KINDS);
+    ndb_filter_add_int_element(&filter, 1);
+    ndb_filter_end_field(&filter);
+    ndb_filter_end(&filter);
+
+    struct ndb_txn txn;
+    if (!ndb_begin_query(ndb, &txn)) {
+        fprintf(stderr, "failed to open read txn\n");
+        ndb_destroy(ndb);
+        return 1;
+    }
+
+    struct ndb_query_result results[8];
+    int count = 0;
+    if (!ndb_query(&txn, &filter, 1, results, 8, &count)) {
+        fprintf(stderr, "query failed\n");
+    } else {
+        printf("found %d notes of kind 1\n", count);
+    }
+
+    ndb_end_query(&txn);
+    ndb_filter_destroy(&filter);
+    ndb_destroy(ndb);
+    return 0;
+}
+```
+
+Compile by linking against `libnostrdb.a` and LMDB/secp256k1 (see `Makefile` for the
+necessary include/link flags).
+
+## 5. Troubleshooting
+
+- **`libsecp256k1` missing** – rerun `./devtools/refresh-submodules.sh deps/secp256k1`
+  and ensure autotools are installed.
+- **`ndb_init` returns false** – check filesystem permissions and whether the configured
+  map size fits on disk; LMDB needs a file large enough to satisfy `ndb_config_set_mapsize`.
+- **`ndb_process_event` fails** – unless you have valid signatures, set
+  `NDB_FLAG_SKIP_NOTE_VERIFY` in development builds.
+- **`query` returns zero rows** – confirm your filters are finalized (`ndb_filter_end`)
+  and that you opened read transactions with `ndb_begin_query`.
+
+Once you are comfortable with the basics, dive into `docs/architecture.md`,
+`docs/api.md`, and `docs/cli.md` for deeper coverage.


### PR DESCRIPTION
## Summary

  - `0b2bcff` Add a real front door to `README.md`: platform requirements,
  quickstart, sample data workflow, and pointers to the new docs.
  - `e2c7c88` Introduce `docs/getting-started.md` with environment setup, build/
  test targets, fixture ingestion, a minimal C example, and troubleshooting
  tips.
  - `a732b86` Document nostrdb’s storage architecture—LMDB layout, packed notes/
  metadata, ingestion/query flow, and guidance for extending the engine safely.
  - `56a7529` Create an API tour covering the major surfaces in `src/nostrdb.h`
  with code snippets for config, ingestion, filters, queries, and metadata
  builders.
  - `8036743` Write a full `ndb` CLI guide detailing every command/flag, common
  workflows, and index-debug helpers.
  - `54a9eda` Catalog the generated C/Rust/Swift bindings, regeneration
  commands, and usage notes so consumers know what’s available today.
  - `ea1ec10` Stand up an mdBook site (`docs/book/`) that stitches all docs into
  a browsable book, plus README instructions for serving/building it.
  - `e0f85d5` Fix mdBook include paths and ignore the build artifacts so `mdbook
  serve docs/book --open` works cleanly.
