### PR TITLE
nostrdb: compute lnurl from lud16/lud06 in profile

### DIFF
--- a/test.c
+++ b/test.c
@@ -1316,7 +1316,7 @@ static void test_fetch_last_noteid()
 	assert(name);
 	assert(lnurl);
 	assert(!strcmp(name, "jb55"));
-	assert(!strcmp(lnurl, "fixme"));
+	assert(!strcmp(lnurl, ""));  // profile has no lud16/lud06
 
 	//printf("note_key %" PRIu64 "\n", key);
 


### PR DESCRIPTION
## Summary
- Fix hardcoded `lnurl = "fixme"` that caused Lightning invoice fetching to fail when zapping users
- Compute lnurl from profile's `lud16` (lightning address) or `lud06` (bech32 lnurl) fields
- Convert `lud16` format `user@domain` to LNURL per LUD-16 spec

## Safety measures
- Proper buffer sizing to prevent overflows (dynamic allocation, defined max sizes)
- JSON string unescaping with support for `\uXXXX` escapes (printable ASCII only)
- `lud06` validation via bech32_decode (BECH32 encoding only, "lnurl" HRP)
- Case-insensitive HRP comparison for uppercase LNURLs
- Rejects control characters and spaces in lightning addresses
- Robust JSON scanner that continues searching on malformed patterns

## Test plan
- [x] Verify zapping users with `lud16` lightning addresses works

Fixes: https://github.com/damus-io/damus/issues/3456
Closes: https://github.com/damus-io/nostrdb/issues/108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LNURL support extraction and processing from user profiles, with automatic fallback handling for multiple lightning address formats.

* **Bug Fixes**
  * Replaced placeholder LNURL values with actual computed values derived from profile data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->