### PR TITLE
debug: add misaligned metadata pointer detection

### DIFF
--- a/src/nostrdb.c
+++ b/src/nostrdb.c
@@ -3922,6 +3922,16 @@ struct ndb_note_meta *ndb_get_note_meta(struct ndb_txn *txn, const unsigned char
 		return NULL;
 	}
 
+	// Debug: detect misaligned metadata pointers before they cause crashes
+	if (((uintptr_t)v.mv_data % 8) != 0) {
+		int i;
+		fprintf(stderr, "ndb: MISALIGNED META ptr=%p (off by %d) size=%zu id=",
+			v.mv_data, (int)((uintptr_t)v.mv_data % 8), v.mv_size);
+		for (i = 0; i < 32; i++)
+			fprintf(stderr, "%02x", id[i]);
+		fprintf(stderr, "\n");
+	}
+
 	return v.mv_data;
 }
 


### PR DESCRIPTION
## Summary

Add debug logging in `ndb_get_note_meta` to detect when LMDB returns misaligned pointers. This helps diagnose the root cause of alignment crashes on iOS before removing the assertion.

The debug output prints to stderr:
- The pointer address and misalignment offset (1-7 bytes)
- The metadata size
- The note ID that triggered the issue

## Example output

```
ndb: MISALIGNED META ptr=0x7fff5004 (off by 4) size=32 id=abc123...
```

## Purpose

This will help determine if the misalignment is:
- **Consistent** (e.g., always off by 4) → structural issue with LMDB/nostrdb
- **Random** → database corruption
- **Specific to certain notes** → isolated bad records

Fixes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)