### PR TITLE
Add visitor queries

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,4 +4,6 @@ export TODO_FILE=TODO
 export JB55=32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245
 export PATH=$PWD:$PATH
 
+source .privenv || :
+
 2>/dev/null todo.sh ls || : 

--- a/docs/ndb_query_visit.md
+++ b/docs/ndb_query_visit.md
@@ -1,0 +1,78 @@
+## Streaming Queries with `ndb_query_visit`
+
+### What problem does this solve?
+
+Before this change, every query in nostrdb worked the same way:
+it collected *all* matching notes into a result buffer in memory, and only then returned them to the caller.
+
+That’s fine for small queries, but it becomes wasteful or impractical when:
+
+* You only need to *look at* results one by one
+* You want to stop early after finding “enough”
+* The result set could be very large
+* You want to process results as a stream instead of storing them all
+
+### The new idea: visit results as they are found
+
+The new `ndb_query_visit` API lets you **stream query results** instead of buffering them.
+
+Instead of saying:
+
+> “Give me an array of results”
+
+you say:
+
+> “Call this function every time you find a result”
+
+That function is called a **visitor**.
+
+### How it works (conceptually)
+
+* nostrdb runs the query exactly the same way as before
+* Each matching note is handed to your visitor callback immediately
+* No result array is allocated
+* Your visitor can decide whether to:
+
+  * keep going
+  * or stop the query early
+
+### Why this is useful
+
+* **Lower memory usage**
+  No large result buffers are allocated.
+
+* **Early exit**
+  If you only need the first N results, you can stop instantly.
+
+* **Streaming / folding**
+  Perfect for counters, aggregations, indexing, filtering, or piping results elsewhere.
+
+* **Same query engine**
+  All existing query plans (ids, authors, kinds, tags, search, etc.) work unchanged.
+
+### Limits still work
+
+Query limits still apply:
+
+* If the filter specifies a `limit`, the visitor will only be called up to that many times
+* If your visitor returns `NDB_VISITOR_STOP`, the query ends immediately
+
+A limit of `0` means “no limit” — the visitor will see everything unless it stops the query.
+
+### How it compares to `ndb_query`
+
+| `ndb_query`                 | `ndb_query_visit`                 |
+| --------------------------- | --------------------------------- |
+| Allocates a result buffer   | No result buffer                  |
+| Returns all results at once | Streams results one by one        |
+| Must store results          | Can process immediately           |
+| Good for small sets         | Ideal for large or unbounded sets |
+
+### Mental model
+
+Think of the difference like this:
+
+* **`ndb_query`** → “give me a list”
+* **`ndb_query_visit`** → “walk the results and call me for each one”
+
+Same database, same filters, same plans — just a more flexible way to consume results.

--- a/ndb.c
+++ b/ndb.c
@@ -269,7 +269,7 @@ static int resolve_pubkeys(struct ndb_txn *txn, int in_fd, int out_fd)
 int main(int argc, char *argv[])
 {
 	struct ndb *ndb;
-	int i, flags, limit, count, current_field, len, res;
+	int i, flags, limit, count, current_field, res;
 	long nanos;
 	struct ndb_stat stat;
 	struct ndb_txn txn;
@@ -417,8 +417,7 @@ int main(int argc, char *argv[])
 					current_field = NDB_FILTER_IDS;
 				}
 
-				len = strlen(argv[1]);
-				if (len != 64 || !hex_decode(argv[1], 64, tmp_id, sizeof(tmp_id))) {
+				if (strlen(argv[1]) != 64 || !hex_decode(argv[1], 64, tmp_id, sizeof(tmp_id))) {
 					fprintf(stderr, "invalid hex id\n");
 					res = 42;
 					goto cleanup;
@@ -437,7 +436,31 @@ int main(int argc, char *argv[])
 				}
 				current_field = 'e';
 
-				if (len != 64 || !hex_decode(argv[1], 64, tmp_id, sizeof(tmp_id))) {
+				if (strlen(argv[1]) != 64 || !hex_decode(argv[1], 64, tmp_id, sizeof(tmp_id))) {
+					fprintf(stderr, "invalid hex id\n");
+					res = 42;
+					goto cleanup;
+				}
+
+				if (!ndb_filter_add_id_element(f, tmp_id)) {
+					fprintf(stderr, "too many event ids\n");
+					res = 43;
+					goto cleanup;
+				}
+
+				argv += 2;
+				argc -= 2;
+			} else if (!strcmp(argv[0], "-p")) {
+				if (current_field != 'p') {
+					if (!ndb_filter_start_tag_field(f, 'p')) {
+						fprintf(stderr, "field already started\n");
+						res = 44;
+						goto cleanup;
+					}
+				}
+				current_field = 'p';
+
+				if (strlen(argv[1]) != 64 || !hex_decode(argv[1], 64, tmp_id, sizeof(tmp_id))) {
 					fprintf(stderr, "invalid hex id\n");
 					res = 42;
 					goto cleanup;
@@ -461,7 +484,7 @@ int main(int argc, char *argv[])
 				}
 				current_field = 'q';
 
-				if (len != 64 || !hex_decode(argv[1], 64, tmp_id, sizeof(tmp_id))) {
+				if (strlen(argv[1]) != 64 || !hex_decode(argv[1], 64, tmp_id, sizeof(tmp_id))) {
 					fprintf(stderr, "invalid hex id\n");
 					res = 42;
 					goto cleanup;
@@ -483,8 +506,7 @@ int main(int argc, char *argv[])
 					current_field = NDB_FILTER_AUTHORS;
 				}
 
-				len = strlen(argv[1]);
-				if (len != 64 || !hex_decode(argv[1], 64, tmp_id, sizeof(tmp_id))) {
+				if (strlen(argv[1]) != 64 || !hex_decode(argv[1], 64, tmp_id, sizeof(tmp_id))) {
 					fprintf(stderr, "invalid hex pubkey\n");
 					res = 42;
 					goto cleanup;
@@ -551,8 +573,7 @@ int main(int argc, char *argv[])
 			argv++;
 			argc--;
 
-			len = strlen(argv[0]);
-			if (len != 64 || !hex_decode(argv[0], 64, tmp_id, sizeof(tmp_id))) {
+			if (strlen(argv[0]) != 64 || !hex_decode(argv[0], 64, tmp_id, sizeof(tmp_id))) {
 				fprintf(stderr, "invalid --add-key hex pubkey\n");
 				res = 42;
 				goto cleanup;

--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -52,9 +52,9 @@ struct bolt11;
  * We explicitly multiply by two in the enum to be unambiguous
  */
 enum ndb_metadata_type {
-    NDB_NOTE_META_RESERVED = 0, /* not used */
-    NDB_NOTE_META_COUNTS   = 100, /* replies, quotes, etc */
-    NDB_NOTE_META_REACTION = 200, /* count of all the reactions on a post, grouped by different reaction strings */
+	NDB_NOTE_META_RESERVED = 0, /* not used */
+	NDB_NOTE_META_COUNTS   = 100, /* replies, quotes, etc */
+	NDB_NOTE_META_REACTION = 200, /* count of all the reactions on a post, grouped by different reaction strings */
 };
 
 #include "nip44.h"

--- a/src/nostrdb.h
+++ b/src/nostrdb.h
@@ -127,6 +127,15 @@ typedef enum ndb_idres (*ndb_id_fn)(void *, const char *);
 // callback function for when we receive new subscription results
 typedef void (*ndb_sub_fn)(void *, uint64_t subid);
 
+struct ndb_query_result {
+	struct ndb_note *note;
+	uint64_t note_size;
+	uint64_t note_id;
+};
+
+// callback function for when we visit a note during a query (used in ndb_query_visit)
+typedef enum ndb_visitor_action (*ndb_visitor_fn)(void *ctx, struct ndb_query_result *res);
+
 // id callback + closure data
 struct ndb_id_cb {
 	ndb_id_fn fn;
@@ -521,14 +530,41 @@ struct ndb_block_iterator {
 	unsigned char *p;
 };
 
-struct ndb_query_result {
-	struct ndb_note *note;
-	uint64_t note_size;
-	uint64_t note_id;
+enum ndb_query_type {
+	/* standard query, fills a result buffer */
+	NDB_QUERY_TYPE_STANDARD = 1,
+
+	/* visitor query. scan/folds over data */
+	NDB_QUERY_TYPE_VISITOR  = 2
+};
+
+/* visitor actions, this allows us to prematurely stop the query */
+enum ndb_visitor_action {
+	NDB_VISITOR_STOP = 0,
+	NDB_VISITOR_CONT = 1,
 };
 
 struct ndb_query_results {
 	struct cursor cur;
+};
+
+struct ndb_query_state {
+	enum ndb_query_type type;
+	uint64_t limit;
+
+	union {
+		struct {
+			int capacity;
+			struct ndb_query_results results;
+		} query;
+
+		struct {
+			uint64_t visited;
+			void *ctx;
+			int done;
+			ndb_visitor_fn visitor;
+		} visitor;
+	};
 };
 
 // CONFIG
@@ -665,6 +701,7 @@ void ndb_text_search_config_set_limit(struct ndb_text_search_config *, int limit
 
 // QUERY
 int ndb_query(struct ndb_txn *txn, struct ndb_filter *filters, int num_filters, struct ndb_query_result *results, int result_capacity, int *count);
+int ndb_query_visit(struct ndb_txn *txn, struct ndb_filter *filters, int num_filters, ndb_visitor_fn visitor, void *ctx);
 
 // NOTE METADATA
 int ndb_note_meta_builder_init(struct ndb_note_meta_builder *builder, unsigned char *, size_t);


### PR DESCRIPTION
## Streaming Queries with `ndb_query_visit`

### What problem does this solve?

Before this change, every query in nostrdb worked the same way:
it collected *all* matching notes into a result buffer in memory, and only then returned them to the caller.

That’s fine for small queries, but it becomes wasteful or impractical when:

* You only need to *look at* results one by one
* You want to stop early after finding “enough”
* The result set could be very large
* You want to process results as a stream instead of storing them all

### The new idea: visit results as they are found

The new `ndb_query_visit` API lets you **stream query results** instead of buffering them.

Instead of saying:

> “Give me an array of results”

you say:

> “Call this function every time you find a result”

That function is called a **visitor**.

### How it works (conceptually)

* nostrdb runs the query exactly the same way as before
* Each matching note is handed to your visitor callback immediately
* No result array is allocated
* Your visitor can decide whether to:

  * keep going
  * or stop the query early

### Why this is useful

* **Lower memory usage**
  No large result buffers are allocated.

* **Early exit**
  If you only need the first N results, you can stop instantly.

* **Streaming / folding**
  Perfect for counters, aggregations, indexing, filtering, or piping results elsewhere.

* **Same query engine**
  All existing query plans (ids, authors, kinds, tags, search, etc.) work unchanged.

### Limits still work

Query limits still apply:

* If the filter specifies a `limit`, the visitor will only be called up to that many times
* If your visitor returns `NDB_VISITOR_STOP`, the query ends immediately

A limit of `0` means “no limit” — the visitor will see everything unless it stops the query.

### How it compares to `ndb_query`

| `ndb_query`                 | `ndb_query_visit`                 |
| --------------------------- | --------------------------------- |
| Allocates a result buffer   | No result buffer                  |
| Returns all results at once | Streams results one by one        |
| Must store results          | Can process immediately           |
| Good for small sets         | Ideal for large or unbounded sets |

### Mental model

Think of the difference like this:

* **`ndb_query`** → “give me a list”
* **`ndb_query_visit`** → “walk the results and call me for each one”

Same database, same filters, same plans — just a more flexible way to consume results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visitor-based streaming query API for incremental processing, early exit, and an "all notes" scan path.

* **Bug Fixes / Improvements**
  * Stronger validation and clearer errors for hex id/pubkey/tag inputs; unified stateful handling to reduce memory during large scans.

* **Documentation**
  * New article explaining the streaming query API, usage patterns, and memory benefits.

* **Chore**
  * Optional, non-fatal sourcing of a hidden environment file at startup (ignored if absent).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->