### PR TITLE
fix: Add ssize_t typedef for Windows MSVC support

### DIFF
--- a/src/base64.h
+++ b/src/base64.h
@@ -5,6 +5,11 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <sys/types.h>
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 
 /**
  * base64_maps_t - structure to hold maps for encode/decode


### PR DESCRIPTION
Fixes build on Windows MSVC. Related to damus-io/notedeck#1253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows build compatibility by adding a missing platform type definition, reducing build errors and improving reliability when compiling on Windows. No public APIs changed; end-users should see no functional differences, while Windows-built installers and binaries will be more consistent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->