### PR TITLE
Index individual words in profile names for search

### DIFF
--- a/src/nostrdb.c
+++ b/src/nostrdb.c
@@ -610,6 +610,38 @@ static void lowercase_strncpy(char *dst, const char *src, int n) {
 	}
 }
 
+static int ndb_strncasecmp(const char *a, const char *b, size_t n)
+{
+	size_t i;
+	for (i = 0; i < n; i++) {
+		int ca = tolower((unsigned char)a[i]);
+		int cb = tolower((unsigned char)b[i]);
+		if (ca != cb)
+			return ca - cb;
+		if (ca == '\0')
+			return 0;
+	}
+	return 0;
+}
+
+static const char *ndb_strcasestr(const char *haystack, const char *needle)
+{
+	size_t nlen;
+
+	if (!haystack || !needle)
+		return NULL;
+
+	nlen = strlen(needle);
+	if (nlen == 0)
+		return haystack;
+
+	for (; *haystack; haystack++) {
+		if (ndb_strncasecmp(haystack, needle, nlen) == 0)
+			return haystack;
+	}
+	return NULL;
+}
+
 static inline int ndb_filter_elem_is_ptr(struct ndb_filter_field *field) {
 	return field->elem_type == NDB_ELEMENT_STRING || field->elem_type == NDB_ELEMENT_ID;
 }
@@ -1628,6 +1660,18 @@ static int ndb_write_profile_search_word_indices(struct ndb_txn *txn,
 								    profile_key))
 					return 0;
 			}
+		}
+	}
+
+	// write per-camelCase-boundary indices
+	// "TheGrinder" -> also index from 'G' boundary -> "grinder"
+	for (p = name; *p && *(p + 1); p++) {
+		if (islower((unsigned char)*p) && isupper((unsigned char)*(p + 1))) {
+			ndb_make_search_key(index, note->pubkey,
+					    note->created_at, p + 1);
+			if (!ndb_write_profile_search_index(txn, index,
+							    profile_key))
+				return 0;
 		}
 	}
 
@@ -4937,6 +4981,77 @@ next:
 	return 1;
 }
 
+static int ndb_profile_search_contains_fallback(
+		struct ndb_txn *txn,
+		const char *search,
+		unsigned char *filter_pubkey,
+		struct ndb_filter *note_filter,
+		struct ndb_query_state *results,
+		unsigned char found_pubkeys[][32],
+		int *num_found)
+{
+	int rc, j, already_found;
+	MDB_cursor *cur;
+	MDB_val k, v;
+	void *profile_root;
+	NdbProfileRecord_table_t record;
+	NdbProfile_table_t profile;
+	struct ndb_note *note;
+	const char *name, *display_name;
+	uint64_t note_key;
+	size_t len;
+
+	if ((rc = mdb_cursor_open(txn->mdb_txn,
+				  txn->lmdb->dbs[NDB_DB_PROFILE], &cur))) {
+		return 0;
+	}
+
+	while (!query_is_full(results) &&
+	       mdb_cursor_get(cur, &k, &v, MDB_NEXT) == 0) {
+		profile_root = v.mv_data;
+		record = NdbProfileRecord_as_root(profile_root);
+		note_key = NdbProfileRecord_note_key(record);
+		note = ndb_get_note_by_key(txn, note_key, &len);
+		if (!note)
+			continue;
+
+		// skip pubkeys already seen (index phase or earlier fallback hits)
+		already_found = 0;
+		for (j = 0; j < *num_found; j++) {
+			if (!memcmp(note->pubkey, found_pubkeys[j], 32)) {
+				already_found = 1;
+				break;
+			}
+		}
+		if (already_found)
+			continue;
+
+		profile = NdbProfileRecord_profile_get(record);
+		name = NdbProfile_name_get(profile);
+		display_name = NdbProfile_display_name_get(profile);
+
+		if ((name && ndb_strcasestr(name, search)) ||
+		    (display_name && ndb_strcasestr(display_name, search))) {
+			// record pubkey before emitting to prevent
+			// duplicate profile rows from re-entering
+			if (*num_found < 64)
+				memcpy(found_pubkeys[(*num_found)++],
+				       note->pubkey, 32);
+
+			memcpy(filter_pubkey, note->pubkey, 32);
+			if (!ndb_query_plan_execute_author_kinds(txn,
+								 note_filter,
+								 results)) {
+				mdb_cursor_close(cur);
+				return 0;
+			}
+		}
+	}
+
+	mdb_cursor_close(cur);
+	return 1;
+}
+
 static int ndb_query_plan_execute_profile_search(
 		struct ndb_txn *txn,
 		struct ndb_filter *filter,
@@ -4952,8 +5067,20 @@ static int ndb_query_plan_execute_profile_search(
 	struct ndb_search profile_search;
 	struct ndb_filter note_filter, *f = &note_filter;
 
+	// track pubkeys found by index phase for dedup
+	unsigned char found_pubkeys[64][32];
+	int num_found = 0;
+
+	// lowercased query for prefix comparison
+	char lowered_query[sizeof(((struct ndb_search_key *)0)->search)];
+	int query_len;
+
 	if (!(search = ndb_filter_find_search(filter)))
 		return 0;
+
+	lowercase_strncpy(lowered_query, search, sizeof(lowered_query) - 1);
+	lowered_query[sizeof(lowered_query) - 1] = '\0';
+	query_len = strlen(lowered_query);
 
 	if (!ndb_filter_init_with(f, 1))
 		return 0;
@@ -4986,8 +5113,18 @@ static int ndb_query_plan_execute_profile_search(
 				break;
 		}
 
+		// stop when index entries no longer prefix-match the query
+		if (strncmp(profile_search.key->search, lowered_query,
+			    query_len) != 0)
+			break;
+
 		// Copy pubkey into filter
 		memcpy(filter_pubkey, profile_search.key->id, 32);
+
+		// record pubkey for dedup with fallback
+		if (num_found < 64)
+			memcpy(found_pubkeys[num_found++],
+			       profile_search.key->id, 32);
 
 		// Look up the corresponding note associated with that pubkey
 		if (!ndb_query_plan_execute_author_kinds(txn, f, results))
@@ -4995,6 +5132,17 @@ static int ndb_query_plan_execute_profile_search(
 	}
 
 	ndb_search_profile_end(&profile_search);
+
+	// if index phase didn't fill results, run linear fallback
+	if (!query_is_full(results)) {
+		if (!ndb_profile_search_contains_fallback(txn, search,
+							  filter_pubkey, f,
+							  results,
+							  found_pubkeys,
+							  &num_found))
+			goto fail;
+	}
+
 	ndb_filter_destroy(f);
 	return 1;
 

--- a/src/nostrdb.c
+++ b/src/nostrdb.c
@@ -1600,6 +1600,40 @@ static int ndb_write_profile_search_index(struct ndb_txn *txn,
 }
 
 
+// write search index entries for each word in a name so that
+// "The Fishcake" is findable by searching "fishcake"
+static int ndb_write_profile_search_word_indices(struct ndb_txn *txn,
+						 struct ndb_search_key *index,
+						 struct ndb_note *note,
+						 uint64_t profile_key,
+						 const char *name)
+{
+	const char *p;
+
+	// write full name index
+	ndb_make_search_key(index, note->pubkey, note->created_at, name);
+	if (!ndb_write_profile_search_index(txn, index, profile_key))
+		return 0;
+
+	// write per-word indices starting from each subsequent word
+	for (p = name; *p; p++) {
+		if (isspace((unsigned char)*p)) {
+			// skip runs of whitespace
+			while (*(p + 1) && isspace((unsigned char)*(p + 1)))
+				p++;
+			if (*(p + 1)) {
+				ndb_make_search_key(index, note->pubkey,
+						    note->created_at, p + 1);
+				if (!ndb_write_profile_search_index(txn, index,
+								    profile_key))
+					return 0;
+			}
+		}
+	}
+
+	return 1;
+}
+
 // map usernames and display names to profile keys for user searching
 static int ndb_write_profile_search_indices(struct ndb_txn *txn,
 					    struct ndb_note *note,
@@ -1616,22 +1650,20 @@ static int ndb_write_profile_search_indices(struct ndb_txn *txn,
 	const char *name = NdbProfile_name_get(profile);
 	const char *display_name = NdbProfile_display_name_get(profile);
 
-	// words + pubkey + created
 	if (name) {
-		ndb_make_search_key(&index, note->pubkey, note->created_at,
-				    name);
-		if (!ndb_write_profile_search_index(txn, &index, profile_key))
+		if (!ndb_write_profile_search_word_indices(txn, &index, note,
+							   profile_key, name))
 			return 0;
 	}
 
 	if (display_name) {
 		// don't write the same name/display_name twice
-		if (name && !strcmp(display_name, name)) {
+		if (name && !strcmp(display_name, name))
 			return 1;
-		}
-		ndb_make_search_key(&index, note->pubkey, note->created_at,
-				    display_name);
-		if (!ndb_write_profile_search_index(txn, &index, profile_key))
+
+		if (!ndb_write_profile_search_word_indices(txn, &index, note,
+							   profile_key,
+							   display_name))
 			return 0;
 	}
 
@@ -2896,12 +2928,24 @@ static int ndb_migrate_utf8_profile_names(struct ndb_txn *txn)
 	return ret;
 }
 
+static int ndb_migrate_word_search_indices(struct ndb_txn *txn)
+{
+	// drop and rebuild search index with per-word entries
+	if (mdb_drop(txn->mdb_txn, txn->lmdb->dbs[NDB_DB_PROFILE_SEARCH], 0)) {
+		fprintf(stderr, "ndb_migrate_word_search_indices: mdb_drop failed\n");
+		return 0;
+	}
+
+	return ndb_migrate_user_search_indices(txn);
+}
+
 static struct ndb_migration MIGRATIONS[] = {
 	{ .fn = ndb_migrate_user_search_indices },
 	{ .fn = ndb_migrate_lower_user_search_indices },
 	{ .fn = ndb_migrate_utf8_profile_names },
 	{ .fn = ndb_migrate_profile_indices },
 	{ .fn = ndb_migrate_metadata },
+	{ .fn = ndb_migrate_word_search_indices },
 };
 
 

--- a/src/nostrdb.c
+++ b/src/nostrdb.c
@@ -5118,6 +5118,20 @@ static int ndb_query_plan_execute_profile_search(
 			    query_len) != 0)
 			break;
 
+		// skip pubkeys we've already emitted (non-consecutive dupes)
+		{
+			int already_found = 0, k;
+			for (k = 0; k < num_found; k++) {
+				if (!memcmp(found_pubkeys[k],
+					    profile_search.key->id, 32)) {
+					already_found = 1;
+					break;
+				}
+			}
+			if (already_found)
+				continue;
+		}
+
 		// Copy pubkey into filter
 		memcpy(filter_pubkey, profile_search.key->id, 32);
 

--- a/test.c
+++ b/test.c
@@ -2827,6 +2827,72 @@ static void test_profile_camelcase_standalone() {
 	printf("ok test_profile_camelcase_standalone\n");
 }
 
+// End-to-end test for index-phase dedup (issue #125).
+//
+// Bug: When a profile name produces multiple search index entries that
+// prefix-match the same query, the same pubkey is emitted multiple times,
+// wasting result slots and hiding other matching profiles.
+//
+// Repro: profile A "Fish Fisherman" produces index entries "fish fisherman"
+// (full name) and "fish" (word split). Query "fish" prefix-matches both,
+// so without dedup profile A appears twice — consuming both result slots
+// and hiding profile B "Fishy".
+//
+// After fix: each pubkey appears at most once, so both profiles are returned.
+static void test_profile_search_index_dedup() {
+	struct ndb *ndb;
+	struct ndb_txn txn;
+	struct ndb_config config;
+	struct ndb_filter filter, *f = &filter;
+	int count;
+	struct ndb_query_result results[2];
+
+	delete_test_db();
+	ndb_default_config(&config);
+	ndb_config_set_flags(&config, NDB_FLAG_SKIP_NOTE_VERIFY);
+	assert(ndb_init(&ndb, test_dir, &config));
+
+	// Profile A: name "Fish Fisherman" — word-split produces entries
+	// "fish fisherman" (full) and "fish" (word). Both prefix-match "fish".
+	const char ev_a[] = "[\"EVENT\",{\"id\": \"0000000000000000000000000000000000000000000000000000000000000a01\",\"pubkey\": \"000000000000000000000000000000000000000000000000000000000000aa01\",\"created_at\": 1700000000,\"kind\": 0,\"tags\": [],\"content\": \"{\\\"name\\\":\\\"Fish Fisherman\\\"}\",\"sig\": \"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"}]";
+
+	// Profile B: name "Fishy" — single entry "fishy". Also prefix-matches "fish".
+	const char ev_b[] = "[\"EVENT\",{\"id\": \"0000000000000000000000000000000000000000000000000000000000000b01\",\"pubkey\": \"000000000000000000000000000000000000000000000000000000000000bb01\",\"created_at\": 1700000001,\"kind\": 0,\"tags\": [],\"content\": \"{\\\"name\\\":\\\"Fishy\\\"}\",\"sig\": \"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"}]";
+
+	assert(ndb_process_client_event(ndb, ev_a, sizeof(ev_a)));
+	assert(ndb_process_client_event(ndb, ev_b, sizeof(ev_b)));
+	sleep(1);
+
+	// Query "fish" with capacity=2.
+	// Without dedup fix: profile A fills both slots (duplicate), profile B hidden.
+	// With dedup fix: profile A once + profile B once = 2 distinct results.
+	assert(ndb_filter_init(f));
+	assert(ndb_filter_start_field(f, NDB_FILTER_SEARCH));
+	assert(ndb_filter_add_str_element(f, "fish"));
+	ndb_filter_end_field(f);
+	assert(ndb_filter_start_field(f, NDB_FILTER_KINDS));
+	assert(ndb_filter_add_int_element(f, 0));
+	ndb_filter_end_field(f);
+	ndb_filter_end(f);
+
+	assert(ndb_begin_query(ndb, &txn));
+	assert(ndb_query(&txn, f, 1, results, 2, &count));
+	ndb_end_query(&txn);
+
+	// Must find exactly 2 distinct profiles
+	assert(count == 2);
+
+	// The two results must have different pubkeys
+	const unsigned char *pk0 = ndb_note_pubkey(results[0].note);
+	const unsigned char *pk1 = ndb_note_pubkey(results[1].note);
+	assert(memcmp(pk0, pk1, 32) != 0);
+
+	ndb_filter_destroy(f);
+	ndb_destroy(ndb);
+
+	printf("ok test_profile_search_index_dedup\n");
+}
+
 static void test_nip50_profile_search() {
 	struct ndb *ndb;
 	struct ndb_txn txn;
@@ -3074,6 +3140,8 @@ int main(int argc, const char *argv[]) {
 	test_timeline_query();
 
 	test_profile_camelcase_standalone();
+
+	test_profile_search_index_dedup();
 
 	// fulltext
 	test_fulltext();

--- a/test.c
+++ b/test.c
@@ -1137,6 +1137,38 @@ static void test_profile_word_search(struct ndb *ndb)
 	ndb_end_query(&txn);
 }
 
+// test that a mid-name prefix query finds the profile via the full-name
+// index entry. "selenej" prefix-matches "selenejin" (the lowercased
+// full name "SeleneJin"). This does NOT exercise camelCase boundary
+// splitting — see test_profile_camelcase_standalone for that.
+static void test_profile_fullname_prefix_search(struct ndb *ndb)
+{
+	struct ndb_txn txn;
+	struct ndb_search search;
+	const char *name;
+	NdbProfile_table_t profile;
+	int found;
+
+	assert(ndb_begin_query(ndb, &txn));
+	assert(ndb_search_profile(&txn, &search, "selenej"));
+
+	found = 0;
+	do {
+		profile = lookup_profile(&txn, search.profile_key);
+		name = NdbProfile_name_get(profile);
+
+		if (name && strstr(name, "Selene")) {
+			found = 1;
+			break;
+		}
+	} while (ndb_search_profile_next(&search));
+
+	assert(found);
+
+	ndb_search_profile_end(&search);
+	ndb_end_query(&txn);
+}
+
 static void test_load_profiles()
 {
 	static const int alloc_size = 1024 * 1024;
@@ -1170,6 +1202,7 @@ static void test_load_profiles()
 
 	test_profile_search(ndb);
 	test_profile_word_search(ndb);
+	test_profile_fullname_prefix_search(ndb);
 
 	ndb_destroy(ndb);
 
@@ -2751,6 +2784,49 @@ static void test_note_relay_index()
 	printf("ok test_note_relay_index\n");
 }
 
+static void test_profile_camelcase_standalone() {
+	struct ndb *ndb;
+	struct ndb_txn txn;
+	struct ndb_config config;
+	struct ndb_filter filter, *f = &filter;
+	int count;
+	struct ndb_query_result result;
+
+	delete_test_db();
+	ndb_default_config(&config);
+	ndb_config_set_flags(&config, NDB_FLAG_SKIP_NOTE_VERIFY);
+	assert(ndb_init(&ndb, test_dir, &config));
+
+	// kind-0 profile with name "TheGrinder" (no spaces anywhere)
+	const char ev[] = "[\"EVENT\",{\"id\": \"0000000000000000000000000000000000000000000000000000000000000001\",\"pubkey\": \"0000000000000000000000000000000000000000000000000000000000000002\",\"created_at\": 1700000000,\"kind\": 0,\"tags\": [],\"content\": \"{\\\"name\\\":\\\"TheGrinder\\\"}\",\"sig\": \"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"}]";
+
+	assert(ndb_process_client_event(ndb, ev, sizeof(ev)));
+
+	// wait for ingestion
+	sleep(1);
+
+	// now search for "grinder" — should find "TheGrinder" via camelCase split
+	assert(ndb_filter_init(f));
+	assert(ndb_filter_start_field(f, NDB_FILTER_SEARCH));
+	assert(ndb_filter_add_str_element(f, "grinder"));
+	ndb_filter_end_field(f);
+	assert(ndb_filter_start_field(f, NDB_FILTER_KINDS));
+	assert(ndb_filter_add_int_element(f, 0));
+	ndb_filter_end_field(f);
+	ndb_filter_end(f);
+
+	assert(ndb_begin_query(ndb, &txn));
+	assert(ndb_query(&txn, f, 1, &result, 1, &count));
+	ndb_end_query(&txn);
+
+	assert(count == 1);
+
+	ndb_filter_destroy(f);
+	ndb_destroy(ndb);
+
+	printf("ok test_profile_camelcase_standalone\n");
+}
+
 static void test_nip50_profile_search() {
 	struct ndb *ndb;
 	struct ndb_txn txn;
@@ -2996,6 +3072,8 @@ int main(int argc, const char *argv[]) {
 	test_fetch_last_noteid();
 
 	test_timeline_query();
+
+	test_profile_camelcase_standalone();
 
 	// fulltext
 	test_fulltext();

--- a/test.c
+++ b/test.c
@@ -1105,6 +1105,38 @@ static void test_profile_updates()
 	free(json);
 }
 
+// test that searching a non-first word in a display name finds the profile.
+// "Selene Jin" should be findable by searching "jin"
+static void test_profile_word_search(struct ndb *ndb)
+{
+	struct ndb_txn txn;
+	struct ndb_search search;
+	const char *name, *display_name;
+	NdbProfile_table_t profile;
+	int found;
+
+	assert(ndb_begin_query(ndb, &txn));
+	assert(ndb_search_profile(&txn, &search, "jin"));
+
+	found = 0;
+	do {
+		profile = lookup_profile(&txn, search.profile_key);
+		name = NdbProfile_name_get(profile);
+		display_name = NdbProfile_display_name_get(profile);
+
+		if ((name && strstr(name, "Jin")) ||
+		    (display_name && strstr(display_name, "Jin"))) {
+			found = 1;
+			break;
+		}
+	} while (ndb_search_profile_next(&search));
+
+	assert(found);
+
+	ndb_search_profile_end(&search);
+	ndb_end_query(&txn);
+}
+
 static void test_load_profiles()
 {
 	static const int alloc_size = 1024 * 1024;
@@ -1137,6 +1169,7 @@ static void test_load_profiles()
 	ndb_end_query(&txn);
 
 	test_profile_search(ndb);
+	test_profile_word_search(ndb);
 
 	ndb_destroy(ndb);
 


### PR DESCRIPTION
## Summary

- Profile search now indexes each word within `name` and `display_name`, not just the full string
- Searching "fishcake" now finds "The Fishcake", searching "grinder" finds "The Grinder", etc.
- Uses `isspace()` to split on any whitespace, skipping runs to avoid empty tokens
- Adds migration to rebuild the search index with per-word entries
- Includes test that verifies searching "jin" finds "Selene Jin"

Closes #123

## Problem

`ndb_write_profile_search_indices()` only wrote a single index entry for the full name. For "The Fishcake" (indexed as `"the fishcake"`), searching `"fishcake"` would start at `'f'` in the LMDB sorted index and exhaust the 128 result limit before ever reaching `'t'`.

## Fix

New helper `ndb_write_profile_search_word_indices()` writes an index entry for each word position. "The Fishcake (android)" gets entries for:
1. `"the fishcake (android)"` (full name, existing behavior)
2. `"fishcake (android)"` (2nd word)
3. `"(android)"` (3rd word)

## Test plan

- [x] `make check` passes (includes new `test_profile_word_search`)
- [x] Search "jin" returns profile with display_name "Selene Jin"
- [x] Existing `test_profile_search` ("jean") still passes

Signed-off-by: alltheseas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile search now matches any word within names and display names, supports camelCase splitting, and mid-name prefix queries for broader matching.

* **Bug Fixes**
  * Improved search reliability with dedup tracking across index and fallback paths and a linear fallback scan when index results are insufficient.

* **Tests**
  * Added unit tests for word-based, camelCase, prefix, and dedup search behaviors.

* **Chores**
  * Migration added to rebuild search indices for per-word matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->