### PR TITLE
Backport "reader check" changes from Damus iOS

### DIFF
--- a/src/nostrdb.c
+++ b/src/nostrdb.c
@@ -218,6 +218,32 @@ struct ndb_lmdb {
 	MDB_dbi dbs[NDB_DBS];
 };
 
+/**
+ * Clears stale LMDB reader slots after opening the environment.
+ *
+ * This protects startup on platforms where reader slots are not reclaimed
+ * automatically after process termination.
+ *
+ * @param[in] env The LMDB environment to inspect.
+ * @return 1 when the check succeeds, 0 when LMDB reports an error.
+ */
+static int ndb_lmdb_reader_check(MDB_env *env)
+{
+	int rc;
+	int dead = 0;
+
+	rc = mdb_reader_check(env, &dead);
+	if (rc != MDB_SUCCESS) {
+		fprintf(stderr, "mdb_reader_check failed: %s\n", mdb_strerror(rc));
+		return 0;
+	}
+
+	if (dead > 0)
+		fprintf(stderr, "mdb_reader_check cleared %d stale reader(s)\n", dead);
+
+	return 1;
+}
+
 struct ndb_writer {
 	struct ndb_lmdb *lmdb;
 	struct ndb_monitor *monitor;
@@ -7748,6 +7774,12 @@ static int ndb_init_lmdb(const char *filename, struct ndb_lmdb *lmdb, size_t map
 
 	if ((rc = mdb_env_open(lmdb->env, filename, 0, 0664))) {
 		fprintf(stderr, "mdb_env_open failed, error %d\n", rc);
+		return 0;
+	}
+
+	if (!ndb_lmdb_reader_check(lmdb->env)) {
+		mdb_env_close(lmdb->env);
+		lmdb->env = NULL;
 		return 0;
 	}
 


### PR DESCRIPTION
This backports the following commit from the Damus iOS repo: https://github.com/damus-io/damus/commit/fe482a9416cb76b8903afdb838793bc98b397dac

The rationale of this change is to reduce the chance of stale reader slots by following this recommendation from `lmdb.h` docs:

```
 *	@section caveats_sec Caveats
 *	Troubleshooting the lock file, plus semaphores on BSD systems:
 *
 *	- A broken lockfile can cause sync issues.
 *	  Stale reader transactions left behind by an aborted program
 *	  cause further writes to grow the database quickly, and
 *	  stale locks can block further operation.
 *
 *	  Fix: Check for stale readers periodically, using the
 *	  #mdb_reader_check function or the \ref mdb_stat_1 "mdb_stat" tool.
 *	  Stale writers will be cleared automatically on some systems:
 *	  - Windows - automatic
 *	  - Linux, systems using POSIX mutexes with Robust option - automatic
 *	  - not on BSD, systems using POSIX semaphores.
 *	  Otherwise just make all programs using the database close it;
 *	  the lockfile is always reset on first open of the environment.
 ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database initialization process with a new startup check that detects and clears stale connection slots, improving startup reliability and preventing potential issues from residual database locks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->