### PR TITLE
Add NIP-09 soft-deletion support

### DIFF
--- a/src/metadata.h
+++ b/src/metadata.h
@@ -83,10 +83,12 @@ STATIC_ASSERT(sizeof(struct ndb_note_meta) == 16, note_meta_entry_should_be_16_b
 
 #pragma pack(pop)
 
+// even bits are reserved for system flags; odd bits are reserved for
+// user-defined flags.
 enum ndb_note_meta_flags {
-	NDB_NOTE_META_FLAG_DELETED      = 0,
-	NDB_NOTE_META_FLAG_SEEN         = 2,
-	NDB_NOTE_META_FLAG_ZAP_VERIFIED = 4,
+	NDB_NOTE_META_FLAG_DELETED      = (1 << 0),
+	NDB_NOTE_META_FLAG_SEEN         = (1 << 2),
+	NDB_NOTE_META_FLAG_ZAP_VERIFIED = (1 << 4),
 };
 
 #endif /* NDB_METADATA_H */

--- a/src/nostrdb.c
+++ b/src/nostrdb.c
@@ -195,6 +195,7 @@ enum ndb_writer_msgtype {
 	NDB_WRITER_MIGRATE, // migrate the database
 	NDB_WRITER_NOTE_RELAY, // we already have the note, but we have more relays to write
 	NDB_WRITER_NOTE_META, // write note metadata to the db
+	NDB_WRITER_DELETE_NOTE, // apply a NIP-09 deletion (soft delete via metadata)
 };
 
 // keys used for storing data in the NDB metadata database (NDB_DB_NDB_META)
@@ -1321,7 +1322,12 @@ static int compare_kinds(const void *pa, const void *pb)
 
 //
 // returns 1 if a filter matches a note
-static int ndb_filter_matches_with(struct ndb_filter *filter,
+//
+// when txn is non-NULL, notes flagged NDB_NOTE_META_FLAG_DELETED in the
+// metadata table are hidden (kind-5 deletion events themselves still pass).
+// pass NULL for pre-write filter checks where no DB lookup is desired.
+static int ndb_filter_matches_with(struct ndb_txn *txn,
+				   struct ndb_filter *filter,
 				   struct ndb_note *note, int already_matched,
 				   struct ndb_note_relay_iterator *relay_iter)
 {
@@ -1329,6 +1335,12 @@ static int ndb_filter_matches_with(struct ndb_filter *filter,
 	struct ndb_filter_elements *els;
 	struct search_id_state state;
 	struct ndb_filter_custom *custom;
+
+	if (txn && note->kind != 5) {
+		struct ndb_note_meta *meta = ndb_get_note_meta(txn, ndb_note_id(note));
+		if (meta && (*ndb_note_meta_flags(meta) & NDB_NOTE_META_FLAG_DELETED))
+			return 0;
+	}
 
 	state.filter = filter;
 
@@ -1427,14 +1439,14 @@ cont:
 
 int ndb_filter_matches(struct ndb_filter *filter, struct ndb_note *note)
 {
-	return ndb_filter_matches_with(filter, note, 0, NULL);
+	return ndb_filter_matches_with(NULL, filter, note, 0, NULL);
 }
 
 int ndb_filter_matches_with_relay(struct ndb_filter *filter,
 				  struct ndb_note *note,
 				  struct ndb_note_relay_iterator *note_relay_iter)
 {
-	return ndb_filter_matches_with(filter, note, 0, note_relay_iter);
+	return ndb_filter_matches_with(NULL, filter, note, 0, note_relay_iter);
 }
 
 // because elements are stored as offsets and qsort doesn't support context,
@@ -2806,6 +2818,11 @@ struct ndb_writer_note_meta {
 	struct ndb_note_meta *metadata;
 };
 
+struct ndb_writer_delete_note {
+	unsigned char target_id[32];
+	unsigned char deleter_pubkey[32];
+};
+
 // Used in the writer thread when writing ndb_profile_fetch_record's
 //   kv = pubkey: recor
 struct ndb_writer_last_fetch {
@@ -2831,6 +2848,7 @@ struct ndb_writer_msg {
 		struct ndb_writer_last_fetch last_fetch;
 		struct ndb_writer_blocks blocks;
 		struct ndb_writer_note_meta note_meta;
+		struct ndb_writer_delete_note delete_note;
 	};
 };
 
@@ -3395,6 +3413,37 @@ static int ndb_ingest_event(struct ndb_ingester *ingester, const char *json,
 }
 
 
+// NIP-09: for each "e" tag, queue a writer message to soft-delete the
+// referenced note. Author verification is performed on the writer side
+// (since we may not have the target yet — see tombstone handling).
+static void ndb_process_deletion_event(struct ndb_ingester *ingester,
+				       struct ndb_note *note)
+{
+	struct ndb_iterator iter;
+	struct ndb_str name, value;
+	struct ndb_writer_msg msg;
+
+	msg.type = NDB_WRITER_DELETE_NOTE;
+	memcpy(msg.delete_note.deleter_pubkey, ndb_note_pubkey(note), 32);
+
+	ndb_tags_iterate_start(note, &iter);
+	while (ndb_tags_iterate_next(&iter)) {
+		if (iter.tag->count < 2)
+			continue;
+
+		name = ndb_tag_str(note, iter.tag, 0);
+		if (name.flag != NDB_PACKED_STR || name.str[0] != 'e' || name.str[1] != '\0')
+			continue;
+
+		value = ndb_tag_str(note, iter.tag, 1);
+		if (value.flag != NDB_PACKED_ID)
+			continue;
+
+		memcpy(msg.delete_note.target_id, value.id, 32);
+		prot_queue_push(ingester->writer_inbox, &msg);
+	}
+}
+
 static int ndb_ingester_process_note(secp256k1_context *secp,
 				     struct ndb_note *note,
 				     size_t note_size,
@@ -3467,6 +3516,9 @@ static int ndb_ingester_process_note(secp256k1_context *secp,
 		ndb_process_pns_event(ingester, note, pns_keys, npns_keys,
 				      relay, scratch, scratch_size,
 				      keys, nkeys, secp);
+	} else if (note->kind == 5) {
+		ndb_process_deletion_event(ingester, note);
+		// kind-5 itself is still written below via NDB_WRITER_NOTE
 	}
 
 	msg.type = NDB_WRITER_NOTE;
@@ -4004,6 +4056,51 @@ struct ndb_note_meta *ndb_get_note_meta(struct ndb_txn *txn, const unsigned char
 	}
 
 	return v.mv_data;
+}
+
+// NIP-09 soft delete. If the target exists, verify the deleter matches the
+// note's author. If the target hasn't arrived yet, trust the kind-5 and mark
+// deleted in advance — the metadata is keyed on note id, so it works whether
+// or not the note is present.
+static int ndb_writer_apply_deletion(struct ndb_txn *txn,
+				     const unsigned char *target_id,
+				     const unsigned char *deleter_pubkey)
+{
+	struct ndb_note *target;
+	struct ndb_note_meta *existing;
+	struct ndb_note_meta hdr;
+	unsigned char scratch[4096];
+	size_t sz;
+	MDB_val k, v;
+	int rc;
+
+	target = ndb_get_note_by_id(txn, target_id, NULL, NULL);
+	if (target && memcmp(ndb_note_pubkey(target), deleter_pubkey, 32) != 0)
+		return 0; // forged: kind-5 author doesn't own the target
+
+	existing = ndb_get_note_meta(txn, target_id);
+	if (existing) {
+		sz = ndb_note_meta_total_size(existing);
+		if (sz > sizeof(scratch))
+			return 0;
+		memcpy(scratch, existing, sz);
+		existing = (struct ndb_note_meta *)scratch;
+		*ndb_note_meta_flags(existing) |= NDB_NOTE_META_FLAG_DELETED;
+		return ndb_writer_set_note_meta(txn, target_id, existing);
+	}
+
+	// no existing metadata: write a minimal header with DELETED set
+	ndb_note_meta_header_init(&hdr);
+	hdr.flags |= NDB_NOTE_META_FLAG_DELETED;
+	k.mv_data = (unsigned char *)target_id;
+	k.mv_size = 32;
+	v.mv_data = &hdr;
+	v.mv_size = sizeof(hdr);
+	if ((rc = mdb_put(txn->mdb_txn, txn->lmdb->dbs[NDB_DB_META], &k, &v, 0))) {
+		ndb_debug("apply_deletion: mdb_put failed: %s\n", mdb_strerror(rc));
+		return 0;
+	}
+	return 1;
 }
 
 /* write reaction stats if its a valid reaction */
@@ -4609,7 +4706,7 @@ static int ndb_query_plan_execute_ids(struct ndb_txn *txn,
 		// things we've already matched via the filter so we don't have
 		// to check again. This can be pretty important for filters
 		// with a large number of entries.
-		if (!ndb_filter_matches_with(filter, note, 1 << NDB_FILTER_IDS, relay_iter)) {
+		if (!ndb_filter_matches_with(txn, filter, note, 1 << NDB_FILTER_IDS, relay_iter)) {
 			ndb_note_relay_iterate_close(relay_iter);
 			continue;
 		}
@@ -4729,7 +4826,7 @@ static int ndb_query_plan_execute_authors(struct ndb_txn *txn,
 			if (need_relays)
 				ndb_note_relay_iterate_start(txn, &note_relay_iter, note_key);
 
-			if (!ndb_filter_matches_with(filter, note,
+			if (!ndb_filter_matches_with(txn, filter, note,
 						     1 << NDB_FILTER_AUTHORS,
 						     need_relays ? &note_relay_iter : NULL))
 			{
@@ -4806,7 +4903,7 @@ static int ndb_query_plan_execute_created_at(struct ndb_txn *txn,
 			ndb_note_relay_iterate_start(txn, &note_relay_iter, note_id);
 
 		// does this entry match our filter?
-		if (!ndb_filter_matches_with(filter, note, 0, need_relays ? &note_relay_iter : NULL))
+		if (!ndb_filter_matches_with(txn, filter, note, 0, need_relays ? &note_relay_iter : NULL))
 			goto next;
 
 		ndb_query_result_init(&res, note, (uint64_t)note_size, note_id);
@@ -4892,7 +4989,7 @@ static int ndb_query_plan_execute_tags(struct ndb_txn *txn,
 			if (need_relays)
 				ndb_note_relay_iterate_start(txn, &note_relay_iter, note_id);
 
-			if (!ndb_filter_matches_with(filter, note,
+			if (!ndb_filter_matches_with(txn, filter, note,
 						     1 << NDB_FILTER_TAGS,
 						     need_relays ? &note_relay_iter : NULL))
 				goto next;
@@ -5003,7 +5100,7 @@ static int ndb_query_plan_execute_author_kinds(
 			if (relays)
 				ndb_note_relay_iterate_start(txn, &note_relay_iter, note_id);
 
-			if (!ndb_filter_matches_with(filter, note,
+			if (!ndb_filter_matches_with(txn, filter, note,
 						     (1 << NDB_FILTER_KINDS) | (1 << NDB_FILTER_AUTHORS),
 						     relays? &note_relay_iter : NULL))
 				goto next;
@@ -5182,7 +5279,7 @@ static int ndb_query_plan_execute_relay_kinds(
 			if (!(note = ndb_get_note_by_key(txn, note_id, &note_size)))
 				goto next;
 
-			if (!ndb_filter_matches_with(filter, note,
+			if (!ndb_filter_matches_with(txn, filter, note,
 						     (1 << NDB_FILTER_KINDS) | (1 << NDB_FILTER_RELAYS),
 						     NULL))
 				goto next;
@@ -5269,7 +5366,7 @@ static int ndb_query_plan_execute_kinds(struct ndb_txn *txn,
 			if (need_relays)
 				ndb_note_relay_iterate_start(txn, &note_relay_iter, note_id);
 
-			if (!ndb_filter_matches_with(filter, note,
+			if (!ndb_filter_matches_with(txn, filter, note,
 						     1 << NDB_FILTER_KINDS,
 						     need_relays ? &note_relay_iter : NULL))
 				goto next;
@@ -7324,6 +7421,7 @@ static void *ndb_writer_thread(void *data)
 			case NDB_WRITER_BLOCKS:
 			case NDB_WRITER_MIGRATE:
 			case NDB_WRITER_NOTE_RELAY:
+			case NDB_WRITER_DELETE_NOTE:
 				needs_commit = 1;
 				break;
 			case NDB_WRITER_QUIT: break;
@@ -7416,6 +7514,11 @@ static void *ndb_writer_thread(void *data)
 						msg->last_fetch.pubkey,
 						msg->last_fetch.fetched_at
 						);
+				break;
+			case NDB_WRITER_DELETE_NOTE:
+				ndb_writer_apply_deletion(&txn,
+						msg->delete_note.target_id,
+						msg->delete_note.deleter_pubkey);
 				break;
 			}
 		}

--- a/test.c
+++ b/test.c
@@ -1,5 +1,6 @@
 
 #include "nostrdb.h"
+#include "metadata.h"
 #include "hex.h"
 #include "io.h"
 #include "bolt11/bolt11.h"
@@ -990,6 +991,262 @@ static void test_multiple_zaps()
 
 	ndb_destroy(ndb);
 	printf("ok test_multiple_zaps\n");
+}
+
+// NIP-09 soft-delete tests
+//
+// note ids and pubkeys are deliberately distinguishable hex bytes (0xa1,
+// 0xb2, etc) so test signatures don't need to be real — we run with
+// NDB_FLAG_SKIP_NOTE_VERIFY.
+
+static void test_delete_soft()
+{
+	struct ndb *ndb;
+	struct ndb_filter filter;
+	struct ndb_config config;
+	struct ndb_txn txn;
+	struct ndb_query_result results[2];
+	uint64_t subid, note_ids[4];
+	int count;
+	ndb_default_config(&config);
+
+	// target: kind 1, id=aaaa..., author=bbbb...
+	const char *target_json =
+		"{\"id\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\","
+		"\"pubkey\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\","
+		"\"created_at\":1700000000,\"kind\":1,\"tags\":[],\"content\":\"delete me\","
+		"\"sig\":\"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\"}";
+
+	// kind 5 from SAME author bbbb... referencing target aaaa...
+	const char *delete_json =
+		"{\"id\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\","
+		"\"pubkey\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\","
+		"\"created_at\":1700000001,\"kind\":5,"
+		"\"tags\":[[\"e\",\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"]],"
+		"\"content\":\"bye\","
+		"\"sig\":\"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\"}";
+
+	static const unsigned char target_id[32] = {
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa
+	};
+	static const unsigned char delete_id[32] = {
+		0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd,
+		0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd,
+		0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd,
+		0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd
+	};
+
+	ndb_config_set_flags(&config, NDB_FLAG_SKIP_NOTE_VERIFY);
+	delete_test_db();
+	assert(ndb_init(&ndb, test_dir, &config));
+
+	// ingest target, wait for writer
+	kind_filter(&filter, 1);
+	subid = ndb_subscribe(ndb, &filter, 1);
+	ndb_process_event(ndb, target_json, strlen(target_json));
+	assert(ndb_wait_for_notes(ndb, subid, note_ids, 4) >= 1);
+	ndb_unsubscribe(ndb, subid);
+	ndb_filter_destroy(&filter);
+
+	// ingest delete, wait for writer
+	kind_filter(&filter, 5);
+	subid = ndb_subscribe(ndb, &filter, 1);
+	ndb_process_event(ndb, delete_json, strlen(delete_json));
+	assert(ndb_wait_for_notes(ndb, subid, note_ids, 4) >= 1);
+	ndb_unsubscribe(ndb, subid);
+	ndb_filter_destroy(&filter);
+
+	// query by id for target — should now be hidden
+	ndb_filter_init(&filter);
+	ndb_filter_start_field(&filter, NDB_FILTER_IDS);
+	ndb_filter_add_id_element(&filter, target_id);
+	ndb_filter_end_field(&filter);
+	ndb_filter_end(&filter);
+
+	ndb_begin_query(ndb, &txn);
+	count = 0;
+	assert(ndb_query(&txn, &filter, 1, results, 2, &count));
+	assert(count == 0);
+
+	// kind-5 itself should still be queryable
+	ndb_filter_destroy(&filter);
+	ndb_filter_init(&filter);
+	ndb_filter_start_field(&filter, NDB_FILTER_IDS);
+	ndb_filter_add_id_element(&filter, delete_id);
+	ndb_filter_end_field(&filter);
+	ndb_filter_end(&filter);
+
+	count = 0;
+	assert(ndb_query(&txn, &filter, 1, results, 2, &count));
+	assert(count == 1);
+
+	// metadata should have DELETED set
+	{
+		struct ndb_note_meta *meta = ndb_get_note_meta(&txn, target_id);
+		assert(meta);
+		assert(*ndb_note_meta_flags(meta) & NDB_NOTE_META_FLAG_DELETED);
+	}
+	ndb_end_query(&txn);
+	ndb_filter_destroy(&filter);
+
+	ndb_destroy(ndb);
+	printf("ok test_delete_soft\n");
+}
+
+static void test_delete_wrong_author()
+{
+	struct ndb *ndb;
+	struct ndb_filter filter;
+	struct ndb_config config;
+	struct ndb_txn txn;
+	struct ndb_query_result results[2];
+	uint64_t subid, note_ids[4];
+	int count;
+	ndb_default_config(&config);
+
+	// target: author bbbb...
+	const char *target_json =
+		"{\"id\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\","
+		"\"pubkey\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\","
+		"\"created_at\":1700000000,\"kind\":1,\"tags\":[],\"content\":\"keep me\","
+		"\"sig\":\"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\"}";
+
+	// kind 5 from DIFFERENT author 9999... — should NOT delete
+	const char *delete_json =
+		"{\"id\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\","
+		"\"pubkey\":\"9999999999999999999999999999999999999999999999999999999999999999\","
+		"\"created_at\":1700000001,\"kind\":5,"
+		"\"tags\":[[\"e\",\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"]],"
+		"\"content\":\"censor!\","
+		"\"sig\":\"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\"}";
+
+	static const unsigned char target_id[32] = {
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa
+	};
+
+	ndb_config_set_flags(&config, NDB_FLAG_SKIP_NOTE_VERIFY);
+	delete_test_db();
+	assert(ndb_init(&ndb, test_dir, &config));
+
+	kind_filter(&filter, 1);
+	subid = ndb_subscribe(ndb, &filter, 1);
+	ndb_process_event(ndb, target_json, strlen(target_json));
+	assert(ndb_wait_for_notes(ndb, subid, note_ids, 4) >= 1);
+	ndb_unsubscribe(ndb, subid);
+	ndb_filter_destroy(&filter);
+
+	kind_filter(&filter, 5);
+	subid = ndb_subscribe(ndb, &filter, 1);
+	ndb_process_event(ndb, delete_json, strlen(delete_json));
+	assert(ndb_wait_for_notes(ndb, subid, note_ids, 4) >= 1);
+	ndb_unsubscribe(ndb, subid);
+	ndb_filter_destroy(&filter);
+
+	// target should still be queryable (forged delete rejected)
+	ndb_filter_init(&filter);
+	ndb_filter_start_field(&filter, NDB_FILTER_IDS);
+	ndb_filter_add_id_element(&filter, target_id);
+	ndb_filter_end_field(&filter);
+	ndb_filter_end(&filter);
+
+	ndb_begin_query(ndb, &txn);
+	count = 0;
+	assert(ndb_query(&txn, &filter, 1, results, 2, &count));
+	assert(count == 1);
+
+	{
+		struct ndb_note_meta *meta = ndb_get_note_meta(&txn, target_id);
+		// either no meta at all, or DELETED not set
+		assert(meta == NULL || !(*ndb_note_meta_flags(meta) & NDB_NOTE_META_FLAG_DELETED));
+	}
+	ndb_end_query(&txn);
+	ndb_filter_destroy(&filter);
+
+	ndb_destroy(ndb);
+	printf("ok test_delete_wrong_author\n");
+}
+
+static void test_delete_out_of_order()
+{
+	struct ndb *ndb;
+	struct ndb_filter filter;
+	struct ndb_config config;
+	struct ndb_txn txn;
+	struct ndb_query_result results[2];
+	uint64_t subid, note_ids[4];
+	int count;
+	ndb_default_config(&config);
+
+	// kind-5 first, target arrives second (same author)
+	const char *delete_json =
+		"{\"id\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\","
+		"\"pubkey\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\","
+		"\"created_at\":1700000001,\"kind\":5,"
+		"\"tags\":[[\"e\",\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"]],"
+		"\"content\":\"bye\","
+		"\"sig\":\"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\"}";
+
+	const char *target_json =
+		"{\"id\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\","
+		"\"pubkey\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\","
+		"\"created_at\":1700000000,\"kind\":1,\"tags\":[],\"content\":\"late\","
+		"\"sig\":\"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\"}";
+
+	static const unsigned char target_id[32] = {
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa
+	};
+
+	ndb_config_set_flags(&config, NDB_FLAG_SKIP_NOTE_VERIFY);
+	delete_test_db();
+	assert(ndb_init(&ndb, test_dir, &config));
+
+	// delete arrives first, target doesn't exist yet
+	kind_filter(&filter, 5);
+	subid = ndb_subscribe(ndb, &filter, 1);
+	ndb_process_event(ndb, delete_json, strlen(delete_json));
+	assert(ndb_wait_for_notes(ndb, subid, note_ids, 4) >= 1);
+	ndb_unsubscribe(ndb, subid);
+	ndb_filter_destroy(&filter);
+
+	// now target arrives
+	kind_filter(&filter, 1);
+	subid = ndb_subscribe(ndb, &filter, 1);
+	ndb_process_event(ndb, target_json, strlen(target_json));
+	assert(ndb_wait_for_notes(ndb, subid, note_ids, 4) >= 1);
+	ndb_unsubscribe(ndb, subid);
+	ndb_filter_destroy(&filter);
+
+	// target should be hidden by the prior tombstone
+	ndb_filter_init(&filter);
+	ndb_filter_start_field(&filter, NDB_FILTER_IDS);
+	ndb_filter_add_id_element(&filter, target_id);
+	ndb_filter_end_field(&filter);
+	ndb_filter_end(&filter);
+
+	ndb_begin_query(ndb, &txn);
+	count = 0;
+	assert(ndb_query(&txn, &filter, 1, results, 2, &count));
+	assert(count == 0);
+
+	{
+		struct ndb_note_meta *meta = ndb_get_note_meta(&txn, target_id);
+		assert(meta);
+		assert(*ndb_note_meta_flags(meta) & NDB_NOTE_META_FLAG_DELETED);
+	}
+	ndb_end_query(&txn);
+	ndb_filter_destroy(&filter);
+
+	ndb_destroy(ndb);
+	printf("ok test_delete_out_of_order\n");
 }
 
 static void test_metadata()
@@ -3224,6 +3481,9 @@ int main(int argc, const char *argv[]) {
 	test_pns_reprocess();
 	test_zap_verification();
 	test_multiple_zaps();
+	test_delete_soft();
+	test_delete_wrong_author();
+	test_delete_out_of_order();
 	test_nip44_round_trip();
 	test_nip44_test_vector();
 	test_nip44_decrypt();


### PR DESCRIPTION
## Summary

- Implements NIP-09 deletion via the existing metadata table. Kind-5 events flip `NDB_NOTE_META_FLAG_DELETED` on the referenced notes' metadata; `ndb_filter_matches_with` hides deleted notes from queries while the kind-5 event itself remains queryable.
- Out-of-order kind-5s are applied to the metadata regardless of whether the target has arrived, since metadata is keyed on note id.
- Targets at-rest are author-checked at apply time (forged deletions are dropped). Pre-emptive kind-5s for not-yet-arrived targets are trusted on arrival — see "Trade-offs" below.
- Also fixes a latent bitmask bug in `enum ndb_note_meta_flags` discovered along the way.

Closes #129.

## Changes

**`src/metadata.h`** — `NDB_NOTE_META_FLAG_*` values were bit positions (0, 2, 4) but were used as bitmasks at `nostrdb.c:8384,8465`. Pre-shifted to `(1<<0), (1<<2), (1<<4)` so direct `|=` / `&` work. Even bits reserved for system flags; odd bits for user-defined.

**`src/nostrdb.c`**
- `ndb_filter_matches_with` now takes a `struct ndb_txn *`. When non-NULL, it short-circuits to 0 for notes flagged DELETED (kind-5s still pass). Public `ndb_filter_matches` / `ndb_filter_matches_with_relay` preserve their signatures and pass NULL.
- New `NDB_WRITER_DELETE_NOTE` writer message; `ndb_writer_apply_deletion` looks up the target, verifies author when present, and ORs in `NDB_NOTE_META_FLAG_DELETED` (or writes a minimal header with the flag).
- `ndb_ingester_process_note` gains a kind-5 branch that emits one `DELETE_NOTE` per `e` tag and still queues the kind-5 itself as `NDB_WRITER_NOTE`.

**`test.c`** — `test_delete_soft`, `test_delete_wrong_author`, `test_delete_out_of_order`.

## Trade-offs

- **Pre-emptive forged deletions**: an attacker who knows a not-yet-published note id can publish a kind-5 referencing it from any pubkey; the target is then hidden on arrival without author verification. Mitigating this would require storing the deleter pubkey in the tombstone (32 bytes), which doesn't fit cleanly until the metadata `data_table` mechanism is fleshed out. Filed as follow-up work if needed.
- **`ZAP_VERIFIED` on-disk bit moves 2 → 4** as part of the bitmask fix. Records written under the old buggy `|= 4` (which actually set bit 2) appear unverified and will re-verify on next pass. No migration needed.
- **`a`-tag deletions** (NIP-09 addressable events) are not implemented in this PR.

## Test plan

- [x] `make && ./test` — full suite passes, including new `test_delete_*` cases
- [ ] Spot-check on real data: ingest a kind-5 from the deleted note's author, confirm queries no longer return the target

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for note deletion; deleted notes are excluded from query results
  * Only note authors can delete their own notes
  * Deletion events remain queryable
  * Correct handling when deletions arrive before their targets

* **Tests**
  * Added comprehensive tests for delete functionality including edge cases and out-of-order scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/damus-io/nostrdb/pull/132)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->