### PR TITLE
Fix block buffer sizing in `ndb_note_to_blocks`

### DIFF
--- a/src/nostrdb.c
+++ b/src/nostrdb.c
@@ -10663,6 +10663,7 @@ static struct ndb_blocks *ndb_note_to_blocks(struct ndb_note *note)
 {
 	const char *content;
 	size_t content_len;
+	size_t buffer_size;
 	struct ndb_blocks *blocks;
 	unsigned char *buffer;
 
@@ -10673,11 +10674,15 @@ static struct ndb_blocks *ndb_note_to_blocks(struct ndb_note *note)
 	if (content_len >= INT32_MAX)
 		return NULL;
 
-	buffer = malloc(2<<18);  // Not carefully calculated, but ok because we will not need this once we switch to the local relay model
+	if (content_len > (INT32_MAX - sizeof(struct ndb_blocks) - 8) / 4)
+		return NULL;
+
+	buffer_size = sizeof(struct ndb_blocks) + (content_len * 4) + 8;
+	buffer = malloc(buffer_size);
 	if (!buffer)
 		return NULL;
 
-	if (!ndb_parse_content(buffer, content_len, content, content_len, &blocks)) {
+	if (!ndb_parse_content(buffer, buffer_size, content, content_len, &blocks)) {
 		free(buffer);
 		return NULL;
 	}


### PR DESCRIPTION
`ndb_note_to_blocks` allocated a fixed 512KB buffer but passed `content_len` as the buffer size to `ndb_parse_content`. The parser bounds its writes by that size argument, so for content larger than the allocation the write cursor ran past the end of the buffer.

Note content comes from untrusted remote events, so a note with sufficiently large content could trigger a heap out-of-bounds write, corrupting adjacent heap memory and leading to a crash or potential memory corruption exploit.

This sizes the buffer to the parser's actual worst case (`sizeof(struct ndb_blocks) + content_len * 4 + 8`), passes that same size to `ndb_parse_content` so the cursor bound matches the allocation, and adds an overflow guard that rejects content too large to size safely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management for note parsing with dynamically sized buffer allocation and enhanced overflow safety checks, ensuring more reliable processing of notes and optimized memory usage across different content sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->